### PR TITLE
[DX-385] Add sourcemaps to server.js during dev, add path to node's vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "build": "node tasks/build.js",
     "git-stage-and-push": "node tasks/git-stage-and-push.js",
     "npm-publish": "node tasks/npm-publish.js",
-    "publish-major": "npm run version-major && npm run test-silent && npm run git-stage-and-push && npm run npm-publish",
-    "publish-minor": "npm run version-minor && npm run test-silent && npm run git-stage-and-push && npm run npm-publish",
-    "publish-patch": "npm run version-patch && npm run test-silent && npm run git-stage-and-push && npm run npm-publish",
+    "publish-major":
+      "npm run version-major && npm run test-silent && npm run git-stage-and-push && npm run npm-publish",
+    "publish-minor":
+      "npm run version-minor && npm run test-silent && npm run git-stage-and-push && npm run npm-publish",
+    "publish-patch":
+      "npm run version-patch && npm run test-silent && npm run git-stage-and-push && npm run npm-publish",
     "precommit": "lint-staged",
     "test": "npm run build && node tasks/mochaTest.js",
     "test-silent": "npm run build && node tasks/mochaTest.js --silent",
@@ -21,10 +24,7 @@
     "version-patch": "node tasks/version.js --type=\"patch\""
   },
   "lint-staged": {
-    "*.js": [
-      "prettier-eslint --single-quote --write",
-      "git add"
-    ]
+    "*.js": ["prettier-eslint --single-quote --write", "git add"]
   },
   "engines": {
     "node": ">=6"
@@ -39,11 +39,7 @@
     "url": "https://github.com/opencomponents/oc/issues"
   },
   "homepage": "https://github.com/opencomponents/oc",
-  "keywords": [
-    "open components",
-    "components",
-    "oc"
-  ],
+  "keywords": ["open components", "components", "oc"],
   "devDependencies": {
     "chai": "3.5.0",
     "chalk": "^2.1.0",
@@ -83,13 +79,13 @@
     "nice-cache": "0.0.5",
     "oc-client": "3.0.7",
     "oc-client-browser": "1.2.3",
-    "oc-get-unix-utc-timestamp": "1.0.1",
+    "oc-get-unix-utc-timestamp": "1.0.2",
     "oc-s3-storage-adapter": "1.1.2",
     "oc-storage-adapters-utils": "1.0.2",
-    "oc-template-handlebars": "6.0.10",
-    "oc-template-handlebars-compiler": "6.1.11",
-    "oc-template-jade": "6.0.9",
-    "oc-template-jade-compiler": "6.1.11",
+    "oc-template-handlebars": "6.0.11",
+    "oc-template-handlebars-compiler": "6.2.0",
+    "oc-template-jade": "6.0.10",
+    "oc-template-jade-compiler": "6.2.0",
     "opn": "5.2.0",
     "parse-author": "2.0.0",
     "pug": "2.0.0-rc.4",

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -87,22 +87,17 @@ module.exports = function(conf) {
       ]);
     },
     getDataProvider: componentName => {
-      if (componentName === 'oc-client') {
-        return fs
-          .readFileSync(
-            path.join(
-              __dirname,
-              '../../components/oc-client/_package/server.js'
-            )
-          )
-          .toString();
-      }
+      const ocClientServerPath =
+        '../../components/oc-client/_package/server.js';
+      const filePath =
+        componentName === 'oc-client'
+          ? path.join(__dirname, ocClientServerPath)
+          : path.join(conf.path, `${componentName}/_package/server.js`);
 
-      return fs
-        .readFileSync(
-          path.join(conf.path, `${componentName}/_package/server.js`)
-        )
-        .toString();
+      return {
+        content: fs.readFileSync(filePath).toString(),
+        filePath
+      };
     }
   };
 
@@ -242,9 +237,14 @@ module.exports = function(conf) {
         return callback(null, local.getDataProvider(componentName));
       }
 
-      cdn.getFile(
-        getFilePath(componentName, componentVersion, 'server.js'),
-        callback
+      const filePath = getFilePath(
+        componentName,
+        componentVersion,
+        'server.js'
+      );
+
+      cdn.getFile(filePath, (err, content) =>
+        callback(err, content ? { content, filePath } : null)
       );
     },
     getStaticClientPath: () =>

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -419,7 +419,7 @@ module.exports = function(conf, repository) {
             repository.getDataProvider(
               component.name,
               component.version,
-              (err, dataProcessorJs) => {
+              (err, dataProvider) => {
                 if (err) {
                   componentCallbackDone = true;
 
@@ -460,8 +460,15 @@ module.exports = function(conf, repository) {
                   returnComponent(err);
                 };
 
+                const options = conf.local
+                  ? {
+                    displayErrors: true,
+                    filename: dataProvider.filePath
+                  }
+                  : {};
+
                 try {
-                  vm.runInNewContext(dataProcessorJs, context);
+                  vm.runInNewContext(dataProvider.content, context, options);
                   const processData = context.module.exports.data;
                   cache.set('file-contents', cacheKey, processData);
 

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -5,8 +5,8 @@ const sinon = require('sinon');
 const _ = require('lodash');
 
 describe('registry : routes : component', () => {
-  const ComponentRoute = require('../../src/registry/routes/component'),
-    mockedComponents = require('../fixtures/mocked-components');
+  const ComponentRoute = require('../../src/registry/routes/component');
+  const mockedComponents = require('../fixtures/mocked-components');
   let mockedRepository, resJsonStub, resSetStub, statusStub, componentRoute;
 
   const templates = {
@@ -20,7 +20,9 @@ describe('registry : routes : component', () => {
     mockedRepository = {
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
-      getDataProvider: sinon.stub().yields(null, params.data),
+      getDataProvider: sinon
+        .stub()
+        .yields(null, { content: params.data, filePath: '/path/to/server.js' }),
       getTemplatesInfo: sinon.stub().returns([
         {
           type: 'oc-template-jade',
@@ -621,12 +623,14 @@ describe('registry : routes : component', () => {
         .onCall(1)
         .yields(null, simpleComponent.package);
 
-      mockedRepository.getDataProvider
-        .onCall(0)
-        .yields(null, headersComponent.data);
-      mockedRepository.getDataProvider
-        .onCall(1)
-        .yields(null, simpleComponent.data);
+      mockedRepository.getDataProvider.onCall(0).yields(null, {
+        content: headersComponent.data,
+        filePath: '/path/to/server.js'
+      });
+      mockedRepository.getDataProvider.onCall(1).yields(null, {
+        content: simpleComponent.data,
+        filePath: '/path/to/another-server.js'
+      });
 
       componentRoute = new ComponentRoute({}, mockedRepository);
 

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -40,7 +40,9 @@ describe('registry : routes : helpers : get-component', () => {
     mockedRepository = {
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
-      getDataProvider: sinon.stub().yields(null, params.data),
+      getDataProvider: sinon
+        .stub()
+        .yields(null, { content: params.data, filePath: '/path/to/server.js' }),
       getTemplatesInfo: sinon.stub().returns([
         {
           type: 'oc-template-jade',


### PR DESCRIPTION
Closes: #440

This is for enabling Visual Studio Code's debugger to fully inspect server.js.

For this to work, the base templates' PR needs to be merged first for enabling source maps to the server.js: https://github.com/opencomponents/base-templates/pull/261