### PR TITLE
[DX-467] Add ES6 template as default core template

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "oc-get-unix-utc-timestamp": "1.0.2",
     "oc-s3-storage-adapter": "1.1.2",
     "oc-storage-adapters-utils": "1.0.2",
+    "oc-template-es6": "^1.0.1",
     "oc-template-handlebars": "6.0.13",
     "oc-template-handlebars-compiler": "6.2.2",
     "oc-template-jade": "6.0.12",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "minimist": "^1.2.0",
     "mocha": "^5.0.0",
     "node-emoji": "^1.8.1",
+    "oc-template-es6-compiler": "^1.0.1",
     "prettier-eslint-cli": "^4.0.4",
     "semver-sort": "0.0.4",
     "simple-git": "^1.77.0",

--- a/src/cli/commands.js
+++ b/src/cli/commands.js
@@ -49,10 +49,10 @@ module.exports = {
     init: {
       cmd: 'init <componentName> [templateType]',
       example: {
-        cmd: '$0 init test-component jade'
+        cmd: '$0 init test-component oc-template-es6'
       },
       description:
-        'Creates a new empty component of a specific template type in the current folder [templateType default: oc-template-handlebars]',
+        'Creates a new empty component of a specific template type in the current folder [templateType default: oc-template-es6]',
       usage: 'Usage: $0 init <componentName> [templateType]'
     },
 

--- a/src/cli/domain/handle-dependencies/require-template.js
+++ b/src/cli/domain/handle-dependencies/require-template.js
@@ -28,14 +28,11 @@ module.exports = function(template, options) {
     template
   );
 
-  [
-    componentRelativePath,
-    template,
-    localTemplate,
-    relativeTemplate
-  ].forEach(pathToTry => {
-    ocTemplate = ocTemplate || cleanRequire(pathToTry, { justTry: true });
-  });
+  [componentRelativePath, template, localTemplate, relativeTemplate].forEach(
+    pathToTry => {
+      ocTemplate = ocTemplate || cleanRequire(pathToTry, { justTry: true });
+    }
+  );
 
   if (!ocTemplate) {
     throw new Error(format(strings.errors.cli.TEMPLATE_NOT_FOUND, template));

--- a/src/cli/facade/init.js
+++ b/src/cli/facade/init.js
@@ -14,7 +14,7 @@ module.exports = function(dependencies) {
   return function(opts, callback) {
     const componentName = opts.componentName;
     const templateType = _.isUndefined(opts.templateType)
-      ? 'oc-template-handlebars'
+      ? 'oc-template-es6'
       : opts.templateType;
     const errors = strings.errors.cli;
     const messages = strings.messages.cli;

--- a/src/components/oc-client/package.json
+++ b/src/components/oc-client/package.json
@@ -21,6 +21,6 @@
     }
   },
   "devDependencies": {
-    "oc-template-es6": "^1.0.1"    
+    "oc-template-es6": "^1.0.1"
   }
 }

--- a/src/components/oc-client/package.json
+++ b/src/components/oc-client/package.json
@@ -21,6 +21,6 @@
     }
   },
   "devDependencies": {
-    "oc-template-es6": "^1.0.1"
+    "oc-template-es6-compiler": "^1.0.1"
   }
 }

--- a/src/components/oc-client/package.json
+++ b/src/components/oc-client/package.json
@@ -12,12 +12,15 @@
     "files": {
       "data": "server.js",
       "template": {
-        "src": "template.jade",
-        "type": "jade"
+        "src": "template.js",
+        "type": "oc-template-es6"
       },
       "static": [
         "src"
       ]
     }
+  },
+  "devDependencies": {
+    "oc-template-es6": "^1.0.1"    
   }
 }

--- a/src/components/oc-client/template.jade
+++ b/src/components/oc-client/template.jade
@@ -1,3 +1,0 @@
-script.
-  window.oc=window.oc||{};oc.conf=oc.conf||{};oc.conf.templates=(oc.conf.templates||[]).concat(!{JSON.stringify(templates)});
-script(src=staticPath+"src/oc-client.min.js", type="text/javascript")

--- a/src/components/oc-client/template.js
+++ b/src/components/oc-client/template.js
@@ -1,5 +1,4 @@
 module.exports = ({ templates, staticPath }) =>
   `<script>window.oc=window.oc||{};oc.conf=oc.conf||{};oc.conf.templates=(oc.conf.templates||[]).concat(${JSON.stringify(
     templates
-  )});</script>
-<script src="${staticPath}src/oc-client.min.js" type="text/javascript"></script>`;
+  )});</script><script src="${staticPath}src/oc-client.min.js" type="text/javascript"></script>`;

--- a/src/components/oc-client/template.js
+++ b/src/components/oc-client/template.js
@@ -1,0 +1,5 @@
+module.exports = ({ templates, staticPath }) =>
+  `<script>window.oc=window.oc||{};oc.conf=oc.conf||{};oc.conf.templates=(oc.conf.templates||[]).concat(${JSON.stringify(
+    templates
+  )});</script>
+<script src="${staticPath}src/oc-client.min.js" type="text/javascript"></script>`;

--- a/src/components/oc-client/template.js
+++ b/src/components/oc-client/template.js
@@ -1,4 +1,4 @@
-module.exports = ({ templates, staticPath }) =>
+export default ({ templates, staticPath }) =>
   `<script>window.oc=window.oc||{};oc.conf=oc.conf||{};oc.conf.templates=(oc.conf.templates||[]).concat(${JSON.stringify(
     templates
   )});</script><script src="${staticPath}src/oc-client.min.js" type="text/javascript"></script>`;

--- a/src/registry/domain/register-templates.js
+++ b/src/registry/domain/register-templates.js
@@ -1,9 +1,10 @@
+const es6Template = require('oc-template-es6');
 const handlebarsTemplate = require('oc-template-handlebars');
 const jadeTemplate = require('oc-template-jade');
 const _ = require('lodash');
 
 module.exports = function(extraTemplates) {
-  const coreTemplates = [jadeTemplate, handlebarsTemplate];
+  const coreTemplates = [es6Template, jadeTemplate, handlebarsTemplate];
   const templates = _.union(coreTemplates, extraTemplates);
   const templatesHash = templates.reduce((hash, template) => {
     try {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -44,6 +44,7 @@ ocClientBrowser.getLib((err, libContent) => {
     const local = new Local();
     const packageOptions = {
       componentPath: path.join(__dirname, clientComponentDir),
+      production: true,
       verbose: false
     };
 

--- a/test/unit/registry-domain-register-templates.js
+++ b/test/unit/registry-domain-register-templates.js
@@ -12,10 +12,12 @@ describe('registry : domain : register-templates', () => {
 
     it('should correctly register core-templates', () => {
       expect(registerd.templatesHash).to.deep.eql({
+        'oc-template-es6': require('oc-template-es6'),
         'oc-template-jade': require('oc-template-jade'),
         'oc-template-handlebars': require('oc-template-handlebars')
       });
       expect(registerd.templatesInfo).to.deep.eql([
+        require('oc-template-es6').getInfo(),
         require('oc-template-jade').getInfo(),
         require('oc-template-handlebars').getInfo()
       ]);
@@ -37,11 +39,13 @@ describe('registry : domain : register-templates', () => {
 
     it('should correctly register core-templates & extra templates', () => {
       expect(registerd.templatesHash).to.deep.eql({
+        'oc-template-es6': require('oc-template-es6'),
         'oc-template-jade': require('oc-template-jade'),
         'oc-template-handlebars': require('oc-template-handlebars'),
         'new-tpl': templateMock
       });
       expect(registerd.templatesInfo).to.deep.eql([
+        require('oc-template-es6').getInfo(),
         require('oc-template-jade').getInfo(),
         require('oc-template-handlebars').getInfo(),
         templateMock.getInfo()
@@ -49,14 +53,16 @@ describe('registry : domain : register-templates', () => {
     });
 
     describe('and additional template is already part of core-templates', () => {
-      const registerd = registerTemplates([require('oc-template-jade')]);
+      const registered = registerTemplates([require('oc-template-jade')]);
 
       it('should correctly register core-templates only', () => {
-        expect(registerd.templatesHash).to.deep.eql({
+        expect(registered.templatesHash).to.deep.eql({
+          'oc-template-es6': require('oc-template-es6'),
           'oc-template-jade': require('oc-template-jade'),
           'oc-template-handlebars': require('oc-template-handlebars')
         });
-        expect(registerd.templatesInfo).to.deep.eql([
+        expect(registered.templatesInfo).to.deep.eql([
+          require('oc-template-es6').getInfo(),
           require('oc-template-jade').getInfo(),
           require('oc-template-handlebars').getInfo()
         ]);

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -132,11 +132,14 @@ describe('registry : domain : repository', () => {
     describe('when getting the list of supported templates', () => {
       describe('when no templates are specificed on the configuaration', () => {
         it('should return core templates', () => {
-          expect(repository.getTemplatesInfo().length).to.equal(2);
+          expect(repository.getTemplatesInfo().length).to.equal(3);
           expect(repository.getTemplatesInfo()[0].type).to.equal(
-            'oc-template-jade'
+            'oc-template-es6'
           );
           expect(repository.getTemplatesInfo()[1].type).to.equal(
+            'oc-template-jade'
+          );
+          expect(repository.getTemplatesInfo()[2].type).to.equal(
             'oc-template-handlebars'
           );
         });
@@ -148,7 +151,7 @@ describe('registry : domain : repository', () => {
             templates: [require('oc-template-jade')]
           });
           const repository = new Repository(conf);
-          expect(repository.getTemplatesInfo().length).to.equal(2);
+          expect(repository.getTemplatesInfo().length).to.equal(3);
         });
       });
 


### PR DESCRIPTION
Introducing ES6 and making it default (oc init component will now default to that).
Due to the default change (but still low impact) we'll publish this as minor.
Jade and Handlebars are still supported and still built-in in the CLI (for now).

Another important aspect, we are making the oc-client component to be es6 - so we'll be able to test immediately that in the new version.