### PR TITLE
Fix git script

### DIFF
--- a/tasks/git-stage-and-push.js
+++ b/tasks/git-stage-and-push.js
@@ -1,11 +1,11 @@
 'use strict';
 
+const changelog = require('./changelog');
 const packageJson = require('../package');
 const path = require('path');
 const simpleGit = require('simple-git');
-const changelog = require('./changelog');
-const git = simpleGit(path.join(__dirname, '..'));
 
+const git = simpleGit(path.join(__dirname, '..'));
 const ocVersion = packageJson.version;
 
 git
@@ -13,6 +13,10 @@ git
   .commit(ocVersion)
   .addAnnotatedTag(`v${ocVersion}`, `Package version upgrade to: ${ocVersion}`)
   .exec(() =>
-    changelog().then(() => git.add('CHANGELOG.md').commit('changelog'))
-  )
-  .push('origin', 'master', { '--follow-tags': null });
+    changelog().then(() =>
+      git
+        .add('CHANGELOG.md')
+        .commit('changelog')
+        .push('origin', 'master', { '--follow-tags': null })
+    )
+  );


### PR DESCRIPTION
I noticed that when doing the npm release script, at the end the changelog wasn't pushed to git.
This should fix I think.