### PR TITLE
ensuring trailing slash to the registry url before removing

### DIFF
--- a/src/cli/domain/registry.js
+++ b/src/cli/domain/registry.js
@@ -142,6 +142,10 @@ module.exports = function(opts) {
       });
     },
     remove: function(registry, callback) {
+      if (registry.slice(registry.length - 1) !== '/') {
+        registry += '/';
+      }
+
       fs.readJson(settings.configFile.src, (err, res) => {
         if (err) {
           res = {};


### PR DESCRIPTION
During add registry url step, we make sure the url ends with a trailing slash (even if it was not supplied by the user) and store the same updated value to the local registry urls list.

But while removing the same, we do not ensure the same. And thus if the user has not supplied a trailing slash to the url, the url is never removed from the local registry urls list. And it silently outputs Ok.

Closes #883