### PR TITLE
Add .idea/ in files patterns to ignore

### DIFF
--- a/src/resources/settings.js
+++ b/src/resources/settings.js
@@ -4,7 +4,7 @@ module.exports = {
   configFile: {
     src: './oc.json'
   },
-  filesToIgnoreOnDevWatch: /node_modules|package\.tar\.gz|_package|\.sw[op]|\.git\/|\.DS_Store|oc\.json/,
+  filesToIgnoreOnDevWatch: /node_modules|package\.tar\.gz|_package|\.sw[op]|\.git\/|\.idea\/|\.DS_Store|oc\.json/,
   maxLoopIterations: 1e9,
   registry: {
     acceptRenderedHeader: 'application/vnd.oc.rendered+json',

--- a/test/unit/resources-settings.js
+++ b/test/unit/resources-settings.js
@@ -34,6 +34,13 @@ describe('resources : settings', () => {
       });
     });
 
+    describe('when something in the .idea folder changes', () => {
+      it('should ignore it', () => {
+        const result = execute('/path/to/.idea/HEAD');
+        expect(result).to.be.true;
+      });
+    });
+
     describe('when node_modules changes', () => {
       it('should ignore it', () => {
         const result = execute('/path/to/node_modules/something-changed');


### PR DESCRIPTION

**Details**
Avoid watching .idea directory during development which contains IDE related files.
IDE keeps updating .idea/workspace.xml which makes the open component unnecesarily load


**Test plan (required)**

resources : settings
    files to watch ignore regex
      when something in the .idea folder changes
        ✓ should ignore it

**Closing issues**
`Issue #887`