### PR TITLE
Lock broken version of es6-compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "minimist": "^1.2.0",
     "mocha": "^5.0.0",
     "node-emoji": "^1.8.1",
-    "oc-template-es6-compiler": "^1.0.1",
+    "oc-template-es6-compiler": "1.1.0",
     "prettier-eslint-cli": "^4.0.4",
     "semver-sort": "0.0.4",
     "simple-git": "^1.77.0",


### PR DESCRIPTION
With the latest version of the es6 compiler, there is an error occurring that is pretty similar to the node 10 one.

Error: https://travis-ci.org/opencomponents/oc/builds/385355960?utm_source=github_status&utm_medium=notification

Node 10: https://github.com/opencomponents/base-templates/pull/295

I managed to get the build green again by pinning the es6 compiler to the previous version. I think it would be nice to merge and publish this in order to have a working patch released first - then we can properly investigate the issue involving the compiler.

/cc @nickbalestra @mattiaerre 