### PR TITLE
add component name to context

### DIFF
--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -374,6 +374,7 @@ module.exports = function(conf, repository) {
             acceptLanguage: acceptLanguageParser.parse(acceptLanguage),
             baseUrl: conf.baseUrl,
             env: conf.env,
+            componentName: component.name,
             params,
             plugins: conf.plugins,
             renderComponent: nestedRenderer.renderComponent,


### PR DESCRIPTION
Add component name to context obj.  Since we have dynamic naming of branch components I have no way of knowing what the name of the current component I am in.  Which is needed for a configuration plugin I am working on.  