### PR TITLE
expose express app to registry

### DIFF
--- a/src/registry/index.js
+++ b/src/registry/index.js
@@ -104,6 +104,7 @@ module.exports = function(options) {
     close,
     on: eventsHandler.on,
     register,
-    start
+    start,
+    app
   };
 };


### PR DESCRIPTION
Expose express app to the registry to allow middleware configurations.