### PR TITLE
Remove support for node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 matrix:
   include:
-    - node_js: "6"
     - node_js: "8"
     - node_js: "9"
     - node_js: "10"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 OpenComponents Community
+Copyright (c) 2019 OpenComponents Community
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -40,14 +40,13 @@ Disclaimer: This project is still under heavy development and the API is likely 
 
 [![linux build](https://img.shields.io/travis/opencomponents/oc/master.svg?label=linux+build)](http://travis-ci.org/opencomponents/oc)
 
-| Node 6| Node 8| Node 9| Node 10| 
-|-------|-------|-------|--------|
-| [![Node6][1]][5]| [![Node8][2]][5] | [![Node9][3]][5] | [![Node10][4]][5] |
+| Node 8| Node 9| Node 10| 
+|-------|-------|--------|
+| [![Node8][1]][5] | [![Node9][2]][5] | [![Node10][3]][5] |
 
 [1]: https://travis-matrix-badges.herokuapp.com/repos/opencomponents/oc/branches/master/1
 [2]: https://travis-matrix-badges.herokuapp.com/repos/opencomponents/oc/branches/master/2
 [3]: https://travis-matrix-badges.herokuapp.com/repos/opencomponents/oc/branches/master/3
-[4]: https://travis-matrix-badges.herokuapp.com/repos/opencomponents/oc/branches/master/4
 [5]: https://travis-ci.org/opencomponents/oc
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,11 @@ version: "{build}"
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 6
+    - nodejs_version: 8
 
 # Get the stable version of node
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm@3
   - node --version
   - npm --version
   - npm install


### PR DESCRIPTION
Remove support for node 6.

We actually did part of this before, but haven't updated the docs and CI. I'll release a new breaking change after this.