### PR TITLE
set headers for getComponents

### DIFF
--- a/src/registry/routes/components.js
+++ b/src/registry/routes/components.js
@@ -9,6 +9,7 @@ const strings = require('../../resources');
 
 module.exports = function(conf, repository) {
   const getComponent = new GetComponentHelper(conf, repository);
+  const setHeaders = (results, res) => results.forEach(result => _.isEmpty(result.headers) || res.set(result.headers));
 
   return function(req, res) {
     const components = req.body.components,
@@ -61,7 +62,10 @@ module.exports = function(conf, repository) {
           result => callback(null, result)
         );
       },
-      (err, results) => res.status(200).json(results)
+      (err, results) => {
+        setHeaders(results,res); 
+        res.status(200).json(results);
+      }
     );
   };
 };

--- a/src/registry/routes/components.js
+++ b/src/registry/routes/components.js
@@ -9,7 +9,12 @@ const strings = require('../../resources');
 
 module.exports = function(conf, repository) {
   const getComponent = new GetComponentHelper(conf, repository);
-  const setHeaders = (results, res) => results.forEach(result => _.isEmpty(result.headers) || res.set(result.headers));
+  const setHeaders = (results, res) => {
+    if (!results || results.length !== 1 || !results[0] || !res.set) {
+      return;
+    }
+    res.set(results[0].headers);
+  };
 
   return function(req, res) {
     const components = req.body.components,
@@ -63,7 +68,7 @@ module.exports = function(conf, repository) {
         );
       },
       (err, results) => {
-        setHeaders(results,res); 
+        setHeaders(results, res);
         res.status(200).json(results);
       }
     );

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -186,9 +186,9 @@ describe('registry', () => {
         );
       });
 
-      it('should not set HTTP custom headers', () => {
-        expect(headers).to.not.have.property('cache-control');
-        expect(headers).to.not.have.property('test-header');
+      it('should set HTTP custom headers', () => {
+        expect(headers).to.have.property('cache-control');
+        expect(headers).to.have.property('test-header');
       });
 
       it('should return the component with custom headers', () => {
@@ -198,6 +198,35 @@ describe('registry', () => {
           'cache-control': 'public max-age=3600',
           'test-header': 'Test-Value'
         });
+      });
+    });
+
+    describe('request with two components', () => {
+      before(done => {
+        request(
+          {
+            url: 'http://localhost:3030',
+            json: true,
+            method: 'post',
+            body: {
+              components: [
+                {
+                  name: 'hello-world-custom-headers',
+                  version: '1.0.0'
+                },
+                {
+                  name: 'hello-world',
+                  version: '1.0.0'
+                }
+              ]
+            }
+          },
+          next(done)
+        );
+      });
+
+      it('should not set HTTP custom headers', () => {
+        expect(headers).to.not.have.property('test-header');
       });
     });
 
@@ -221,9 +250,9 @@ describe('registry', () => {
         );
       });
 
-      it('should not set HTTP custom headers', () => {
-        expect(headers).to.not.have.property('cache-control');
-        expect(headers).to.not.have.property('test-header');
+      it('should set HTTP custom headers', () => {
+        expect(headers).to.have.property('cache-control');
+        expect(headers).to.have.property('test-header');
       });
 
       it('should return the component with custom headers in the response body', () => {
@@ -273,9 +302,9 @@ describe('registry', () => {
           );
         });
 
-        it('should not set HTTP custom headers', () => {
-          expect(headers).to.not.have.property('cache-control');
-          expect(headers).to.not.have.property('test-header');
+        it('should set HTTP custom headers', () => {
+          expect(headers).to.have.property('cache-control');
+          expect(headers).to.have.property('test-header');
         });
 
         it('should return the component with the custom headers', () => {
@@ -310,9 +339,8 @@ describe('registry', () => {
           );
         });
 
-        it('should not set HTTP custom headers', () => {
-          expect(headers).to.not.have.property('cache-control');
-          expect(headers).to.not.have.property('test-header');
+        it('should have HTTP custom headers', () => {
+          expect(headers).to.have.property('test-header');
         });
 
         it('should skip Cache-Control header', () => {


### PR DESCRIPTION
Fix issue: 
https://github.com/opencomponents/oc/issues/1023

**Test plan (required)**
Setting a header using context in server.js
![image](https://user-images.githubusercontent.com/40531/56231841-67b25700-604d-11e9-8d7a-44b1f8b0c8e7.png)

From: client side:
![image](https://user-images.githubusercontent.com/40531/56232088-f3c47e80-604d-11e9-8501-2e1063ee19da.png)

Result: No cookie..

After change: (Cookie!)
![image](https://user-images.githubusercontent.com/40531/56232158-1a82b500-604e-11e9-9fe7-2224f90c05b3.png)




**Closing issues**
closes #1023
