### PR TITLE
add off method (like EventListener.off)

### DIFF
--- a/src/registry/domain/events-handler.js
+++ b/src/registry/domain/events-handler.js
@@ -25,6 +25,15 @@ module.exports = {
 
     subscriptions[eventName].push(callback);
   },
+  off: function(eventName, callback) {
+    if (!_.isFunction(callback)) {
+      throw strings.errors.registry.CONFIGURATION_OFFREQUEST_MUST_BE_FUNCTION;
+    }
+
+    if (subscriptions[eventName]) {
+      _.pull(subscriptions[eventName], callback);
+    }
+  },
   reset: function() {
     subscriptions = {};
   }

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -92,6 +92,8 @@ module.exports = {
       CONFIGURATION_EMPTY: 'Registry configuration is empty',
       CONFIGURATION_ONREQUEST_MUST_BE_FUNCTION:
         "Registry configuration is not valid: registry.on's callback must be a function",
+      CONFIGURATION_OFFREQUEST_MUST_BE_FUNCTION:
+        "Registry configuration is not valid: registry.off's callback must be a function",
       CONFIGURATION_PUBLISH_BASIC_AUTH_CREDENTIALS_MISSING:
         'Registry configuration is not valid: basic auth requires username and password',
       CONFIGURATION_PUBLISH_AUTH_MODULE_NOT_FOUND:

--- a/test/unit/registry-domain-events-handler.js
+++ b/test/unit/registry-domain-events-handler.js
@@ -80,9 +80,7 @@ describe('registry : domain : events-handler', () => {
       );
     });
     it('should not throw an error if event name is not registered', () => {
-      expect(execute).not.to.throw(
-        "Registry configuration is not valid: registry.off's callback must be a function"
-      );
+      expect(execute).not.to.throw();
     });
     it('should remove the specific callback but not the others', () => {
       const spy = sinon.spy();

--- a/test/unit/registry-domain-events-handler.js
+++ b/test/unit/registry-domain-events-handler.js
@@ -65,4 +65,37 @@ describe('registry : domain : events-handler', () => {
       );
     });
   });
+
+  describe('when unsubscribing a request event', () => {
+    const executeNonFunction = function() {
+      eventsHandler.off('request', 'this is not a function');
+    };
+    const execute = function() {
+      eventsHandler.off('request', () => {});
+    };
+
+    it('should throw an error if callback is not a function', () => {
+      expect(executeNonFunction).to.throw(
+        "Registry configuration is not valid: registry.off's callback must be a function"
+      );
+    });
+    it('should not throw an error if event name is not registered', () => {
+      expect(execute).not.to.throw(
+        "Registry configuration is not valid: registry.off's callback must be a function"
+      );
+    });
+    it('should remove the specific callback but not the others', () => {
+      const spy = sinon.spy();
+      const spyToBeRemoved = sinon.spy();
+      eventsHandler.on('eventName', spy);
+      eventsHandler.on('eventName', spyToBeRemoved);
+
+      eventsHandler.off('eventName', spyToBeRemoved);
+      eventsHandler.fire('eventName', {});
+
+      expect(spy.called).to.be.true;
+      expect(spyToBeRemoved.called).not.to.be.true;
+      eventsHandler.reset();
+    });
+  });
 });


### PR DESCRIPTION
Closes #296 

Adding an off method resembling [EventEmitter.off](https://nodejs.org/api/events.html#events_emitter_off_eventname_listener)

Behaviour is the same as in there (fails if you don't pass a function, does nothing if the eventName is not registered). Added some tests for those scenarios.