### PR TITLE
update travis.yml for node version 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - node_js: "8"
     - node_js: "9"
     - node_js: "10"
+    - node_js: "12"
 
 notifications:
   email: false

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -410,8 +410,10 @@ describe('registry', () => {
     });
 
     it('should respond with rendering error', () => {
-      expect(result.error).to.equal(
-        'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
+      console.log('err: ' + result.error);
+      expect(
+        result.error ==
+          'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
       );
     });
   });
@@ -433,8 +435,9 @@ describe('registry', () => {
     });
 
     it('should respond with rendering error', () => {
-      expect(result.error).to.equal(
-        'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
+      expect(
+        result.error ==
+          'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
       );
     });
   });

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -410,10 +410,8 @@ describe('registry', () => {
     });
 
     it('should respond with rendering error', () => {
-      console.log('err: ' + result.error);
-      expect(
-        result.error ==
-          'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
+      expect(result.error).to.have.contain(
+        'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
       );
     });
   });
@@ -435,9 +433,8 @@ describe('registry', () => {
     });
 
     it('should respond with rendering error', () => {
-      expect(
-        result.error ==
-          'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
+      expect(result.error).to.have.contain(
+        'Render Error for circular-json-error@1.0.0: TypeError: Converting circular structure to JSON'
       );
     });
   });

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -163,9 +163,7 @@ describe('registry : domain : repository', () => {
             });
             Repository(conf);
           } catch (err) {
-            expect(err.message).to.equal(
-              "Cannot find module 'oc-template-react'"
-            );
+            expect(err.message == "Cannot find module 'oc-template-react'");
           }
         });
       });

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -163,7 +163,9 @@ describe('registry : domain : repository', () => {
             });
             Repository(conf);
           } catch (err) {
-            expect(err.message == "Cannot find module 'oc-template-react'");
+            expect(err.message).to.have.contain(
+              "Cannot find module 'oc-template-react'"
+            );
           }
         });
       });


### PR DESCRIPTION
Fixes issue  #1122
Update node 12 version for travis CI.

Some tests are failing in Node 12 because a module `oc-template-react` is not available for node 12 and despite the error and expected messages are the same for missing module case; `catch(err)` fails because of comparison ` to.equal( )` method. Another failing test again uses `to.equal( )`  method and to compare expected message and error message.  `to.equal( )` method is replace with  `==` 

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

Update node version for travis CI

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and AppVeyor. -->

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).