### PR TITLE
prevent package.json changing when calling oc dev

### DIFF
--- a/src/utils/npm-utils.js
+++ b/src/utils/npm-utils.js
@@ -9,6 +9,8 @@ const buildInstallCommand = options => {
   if (options.save) {
     args.push('--save-exact');
     args.push(options.isDev ? '--save-dev' : '--save');
+  } else {
+    args.push('--no-save');
   }
 
   return args;

--- a/test/unit/utils-npm-utils.js
+++ b/test/unit/utils-npm-utils.js
@@ -92,6 +92,7 @@ describe('utils : npm-utils', () => {
           'install',
           '--prefix',
           'path/to/component',
+          '--no-save',
           'lodash',
           '--no-package-lock'
         ]
@@ -119,6 +120,7 @@ describe('utils : npm-utils', () => {
           'install',
           '--prefix',
           'path/to/component',
+          '--no-save',
           'oc-client@~1.2.3',
           '--no-package-lock'
         ]
@@ -199,6 +201,7 @@ describe('utils : npm-utils', () => {
           'install',
           '--prefix',
           'path/to/component',
+          '--no-save',
           'moment',
           'lodash',
           '--no-package-lock'
@@ -232,6 +235,7 @@ describe('utils : npm-utils', () => {
           'install',
           '--prefix',
           'path/to/component',
+          '--no-save',
           'oc-client@~1.2.3',
           'oc-template-react-compiler',
           '--no-package-lock'


### PR DESCRIPTION
This addresses issue #796.


Since npm made `--save` the default behaviour, oc has been modifying the package.json file accidentally. This ensures that the package.json file remains untouched.

Please do not create a Pull Request without creating an issue first.
Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Create a new project using `oc init hello-world` and then delete the following folders if they exist: `node_modules`, `_package`.
view the component's package.json file:
```json
  "devDependencies": {
    "oc-template-es6-compiler": "1.1.8"
  }
```
Now run `oc dev .`
Notice that the package.json file changed:
```json
  "devDependencies": {
    "oc-template-es6-compiler": "^1.1.8"
  }
```

Now apply this fix.

Notice that the package.json file remains unchanged.

<!-- Make sure tests pass on both Travis and AppVeyor. -->

**Closing issues**
closes #796 