### PR TITLE
[SFX-2153] - Upgrading Handlerbars render to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "oc-s3-storage-adapter": "1.1.6",
     "oc-storage-adapters-utils": "1.0.3",
     "oc-template-es6": "1.0.1",
-    "oc-template-handlebars": "6.0.17",
+    "oc-template-handlebars": "6.0.18",
     "oc-template-handlebars-compiler": "6.2.10",
     "oc-template-jade": "7.0.0",
     "oc-template-jade-compiler": "7.0.1",


### PR DESCRIPTION
Hi,

This is the first of two PRs, which has the intent of upgrading the version of handlebars that is used within OC from version 4.5.3 to 4.7.6.

For this issue to be fully fixed it requires the handlebars render & compiler. This PR address upgrading the render.

**Test plan (required)**
- Testing done locally by referencing the latest version of oc-template-handlebars.

- I tested this with a number of different components & compilers and I've encountered no issues.

<!-- Make sure tests pass on both Travis and AppVeyor. -->

**Closing issues**

Helps to close issues: https://github.com/opencomponents/oc/issues/1169