### PR TITLE
Respect cdn.maxConcurrentRequests in components-list

### DIFF
--- a/src/registry/domain/components-cache/components-list.js
+++ b/src/registry/domain/components-cache/components-list.js
@@ -42,7 +42,7 @@ module.exports = (conf, cdn) => {
             return callback(err);
           }
 
-          async.map(components, getVersionsForComponent, (errors, versions) => {
+          async.mapLimit(components, cdn.maxConcurrentRequests, getVersionsForComponent, (errors, versions) => {
             if (errors) {
               return callback(errors);
             }

--- a/test/unit/registry-domain-components-cache.js
+++ b/test/unit/registry-domain-components-cache.js
@@ -8,7 +8,8 @@ describe('registry : domain : components-cache', () => {
   const mockedCdn = {
     getJson: sinon.stub(),
     listSubDirectories: sinon.stub(),
-    putFileContent: sinon.stub()
+    putFileContent: sinon.stub(),
+    maxConcurrentRequests: 10
   };
 
   const baseOptions = {


### PR DESCRIPTION
Storage adapter defines `maxConcurrentRequests`, which was used in `components-details`, but not in `components-list`. This causes ECONNRESET errors in azure storage adapter, because too many concurrent connections are made.
Fix by using async.mapLimit.

**Closing issues**

closes #1179