### PR TITLE
Add support for custom keepAliveTimeout config

### DIFF
--- a/src/registry/domain/options-sanitiser.js
+++ b/src/registry/domain/options-sanitiser.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const settings = require('../../resources/settings');
 const auth = require('./authentication');
 
+const DEFAULT_NODE_KEEPALIVE_MS = 5000;
+
 module.exports = function(input) {
   const options = _.clone(input);
 
@@ -58,6 +60,8 @@ module.exports = function(input) {
 
   options.port = process.env.PORT || options.port;
   options.timeout = options.timeout || 1000 * 60 * 2;
+  options.keepAliveTimeout =
+    options.keepAliveTimeout || DEFAULT_NODE_KEEPALIVE_MS;
 
   if (options.s3) {
     options.storage = {};

--- a/src/registry/index.js
+++ b/src/registry/index.js
@@ -66,6 +66,7 @@ module.exports = function(options) {
 
         server = http.createServer(app);
         server.timeout = options.timeout;
+        server.keepAliveTimeout = options.keepAliveTimeout;
 
         server.listen(options.port, err => {
           if (err) {


### PR DESCRIPTION
We need to pass in a custom `keepAliveTimeout` to the HTTP server for some of our work at OpenTable.

This PR adds support for that. If no `keepAliveTimeout` is present in the configuration, we default back to 5000ms, which is the Node default.