### PR TITLE
Fix tests for windows

### DIFF
--- a/test/unit/cli-facade-init.js
+++ b/test/unit/cli-facade-init.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const injectr = require('injectr');
@@ -99,7 +100,7 @@ describe('cli : facade : init', () => {
 
       it('should show a correct path in the log message', () => {
         expect(logSpy.log.args[0][0]).to.contain(
-          '/this/is/relative/path/to/the-best-component'
+          path.join('/this/is/relative/path/to/the-best-component')
         );
       });
     });

--- a/test/unit/utils-strip-version.js
+++ b/test/unit/utils-strip-version.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const path = require('path');
 
 describe('utils : stripVersion', () => {
   const stripVersion = require('../../src/utils/strip-version');
@@ -12,7 +13,7 @@ describe('utils : stripVersion', () => {
       const name = stripVersion(dependency + '@1.0.0');
 
       it('should return the dependency without the version', () => {
-        expect(name).to.equal('/path/to/dependency');
+        expect(name).to.equal(path.join('/path/to/dependency'));
       });
     });
 
@@ -20,7 +21,7 @@ describe('utils : stripVersion', () => {
       const name = stripVersion(dependency);
 
       it('should return the unmodified dependency', () => {
-        expect(name).to.equal('/path/to/dependency');
+        expect(name).to.equal(path.join('/path/to/dependency'));
       });
     });
   });
@@ -32,7 +33,7 @@ describe('utils : stripVersion', () => {
       const name = stripVersion(dependency + '@1.2.3');
 
       it('should return the dependency without the version', () => {
-        expect(name).to.equal('/path/to/@the-scoped/package');
+        expect(name).to.equal(path.join('/path/to/@the-scoped/package'));
       });
     });
 
@@ -40,7 +41,7 @@ describe('utils : stripVersion', () => {
       const name = stripVersion(dependency);
 
       it('should return the unmodified dependency', () => {
-        expect(name).to.equal('/path/to/@the-scoped/package');
+        expect(name).to.equal(path.join('/path/to/@the-scoped/package'));
       });
     });
   });


### PR DESCRIPTION
Some tests relies on expecting paths, so windows uses '\\' instead of '/' for those and they fail. We wrap those with path.join so is OS specific, and now the tests will work both in Windows and Unix.