### PR TITLE
Fix handling of missing dependencies

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "useTabs": false,
+  "arrowParens": "always"
+}

--- a/src/cli/domain/handle-dependencies/get-missing-dependencies.js
+++ b/src/cli/domain/handle-dependencies/get-missing-dependencies.js
@@ -3,13 +3,13 @@
 const path = require('path');
 const _ = require('lodash');
 
-const cleanRequire = require('../../../utils/clean-require');
+const moduleExists = require('../../../utils/module-exists');
 
-module.exports = dependencies => {
+module.exports = (dependencies) => {
   const missing = [];
   _.each(dependencies, (version, dependency) => {
     const pathToModule = path.resolve('node_modules/', dependency);
-    if (!cleanRequire(pathToModule, { justTry: true, resolve: true })) {
+    if (!moduleExists(pathToModule)) {
       missing.push(`${dependency}@${version || 'latest'}`);
     }
   });

--- a/src/utils/module-exists.js
+++ b/src/utils/module-exists.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const tryRequire = require('try-require');
+const path = require('path');
+
+module.exports = (moduleName) => {
+  const packageModulePath = path.join(moduleName, 'package.json');
+
+  if (require.cache && !!require.cache[packageModulePath]) {
+    delete require.cache[packageModulePath];
+  }
+
+  return (
+    !!tryRequire.resolve(moduleName) || !!tryRequire.resolve(packageModulePath)
+  );
+};

--- a/test/unit/cli-domain-handle-dependencies-get-missing-dependencies.js
+++ b/test/unit/cli-domain-handle-dependencies-get-missing-dependencies.js
@@ -24,19 +24,19 @@ describe('cli : domain : handle-dependencies - get-missing-dependencies', () => 
     }
   ];
 
-  scenarios.forEach(scenario => {
+  scenarios.forEach((scenario) => {
     const { dependencies, installed, output } = scenario;
     describe(`When dependencies: ${JSON.stringify(
       dependencies
     )} and installed: ${JSON.stringify(installed)}`, () => {
       const pathResolveSpy = sinon.spy();
-      const cleanRequireSpy = sinon.spy();
+      const moduleExistsSpy = sinon.spy();
       const getMissingDependencies = injectr(
         '../../src/cli/domain/handle-dependencies/get-missing-dependencies.js',
         {
-          '../../../utils/clean-require': (name, options) => {
-            cleanRequireSpy(name, options);
-            return installed[name] ? { dependency: true } : undefined;
+          '../../../utils/module-exists': (name) => {
+            moduleExistsSpy(name);
+            return installed[name];
           },
           path: {
             resolve: (...args) => {
@@ -56,12 +56,8 @@ describe('cli : domain : handle-dependencies - get-missing-dependencies', () => 
           expect(pathResolveCall[0]).to.equal('node_modules/');
           expect(pathResolveCall[1]).to.equal(_.keys(dependencies)[i]);
         });
-        cleanRequireSpy.args.forEach((cleanRequireCall, i) => {
-          expect(cleanRequireCall[0]).to.equal(_.keys(dependencies)[i]);
-          expect(cleanRequireCall[1]).to.eql({
-            justTry: true,
-            resolve: true
-          });
+        moduleExistsSpy.args.forEach((moduleExistsCall, i) => {
+          expect(moduleExistsCall[0]).to.equal(_.keys(dependencies)[i]);
         });
       });
     });


### PR DESCRIPTION
The issue was that for some packages, there is not an entry point
defined in the package.json, so trying to require the module is not an
effective way to determine if the package is installed, so we try to
also require the package.json from that library to make the check more
robust.

Closes #964 