### PR TITLE
Available plugins

### DIFF
--- a/src/registry/domain/plugins-initialiser.js
+++ b/src/registry/domain/plugins-initialiser.js
@@ -98,6 +98,8 @@ module.exports.init = function(pluginsToRegister, callback) {
     plugin.register.register(plugin.options || {}, dependencies, err => {
       const pluginCallback = plugin.callback || _.noop;
       pluginCallback(err);
+      // Overriding toString so implementation details of plugins do not
+      // leak to OC consumers
       plugin.register.execute.toString = () => plugin.description || '';
       registered[plugin.name] = plugin.register.execute;
       done(err);

--- a/src/registry/domain/plugins-initialiser.js
+++ b/src/registry/domain/plugins-initialiser.js
@@ -98,6 +98,7 @@ module.exports.init = function(pluginsToRegister, callback) {
     plugin.register.register(plugin.options || {}, dependencies, err => {
       const pluginCallback = plugin.callback || _.noop;
       pluginCallback(err);
+      plugin.register.execute.toString = () => plugin.description || '';
       registered[plugin.name] = plugin.register.execute;
       done(err);
     });

--- a/src/registry/router.js
+++ b/src/registry/router.js
@@ -8,8 +8,9 @@ const ComponentInfoRoute = require('./routes/component-info');
 const ComponentPreviewRoute = require('./routes/component-preview');
 const IndexRoute = require('./routes');
 const PublishRoute = require('./routes/publish');
-const settings = require('../resources/settings');
 const StaticRedirectorRoute = require('./routes/static-redirector');
+const PluginsRoute = require('./routes/plugins');
+const settings = require('../resources/settings');
 
 module.exports.create = function(app, conf, repository) {
   const routes = {
@@ -19,7 +20,8 @@ module.exports.create = function(app, conf, repository) {
     componentPreview: new ComponentPreviewRoute(conf, repository),
     index: new IndexRoute(repository),
     publish: new PublishRoute(repository),
-    staticRedirector: new StaticRedirectorRoute(repository)
+    staticRedirector: new StaticRedirectorRoute(repository),
+    plugins: new PluginsRoute(conf)
   };
 
   const prefix = conf.prefix;
@@ -32,11 +34,11 @@ module.exports.create = function(app, conf, repository) {
   app.get(`${prefix}oc-client/client.js`, routes.staticRedirector);
   app.get(`${prefix}oc-client/oc-client.min.map`, routes.staticRedirector);
 
+  app.get(`${prefix}~registry/plugins`, routes.plugins);
+
   if (conf.local) {
     app.get(
-      `${prefix}:componentName/:componentVersion/${
-        settings.registry.localStaticRedirectorPath
-      }*`,
+      `${prefix}:componentName/:componentVersion/${settings.registry.localStaticRedirectorPath}*`,
       routes.staticRedirector
     );
   } else {
@@ -51,9 +53,7 @@ module.exports.create = function(app, conf, repository) {
   app.post(prefix, routes.components);
 
   app.get(
-    `${prefix}:componentName/:componentVersion${
-      settings.registry.componentInfoPath
-    }`,
+    `${prefix}:componentName/:componentVersion${settings.registry.componentInfoPath}`,
     routes.componentInfo
   );
   app.get(
@@ -62,9 +62,7 @@ module.exports.create = function(app, conf, repository) {
   );
 
   app.get(
-    `${prefix}:componentName/:componentVersion${
-      settings.registry.componentPreviewPath
-    }`,
+    `${prefix}:componentName/:componentVersion${settings.registry.componentPreviewPath}`,
     routes.componentPreview
   );
   app.get(

--- a/src/registry/routes/plugins.js
+++ b/src/registry/routes/plugins.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = function(conf) {
+  return function(req, res) {
+    if (conf.discovery) {
+      const plugins = Object.entries(conf.plugins).map(
+        ([pluginName, pluginFn]) => ({
+          name: pluginName,
+          description: pluginFn.toString()
+        })
+      );
+
+      res.status(200).json(plugins);
+    } else {
+      res.status(401);
+    }
+  };
+};

--- a/src/registry/views/index.js
+++ b/src/registry/views/index.js
@@ -3,7 +3,8 @@ module.exports = vm => {
     dependencies: require('./partials/components-dependencies')(vm),
     history: require('./partials/components-history')(vm),
     list: require('./partials/components-list')(vm),
-    templates: require('./partials/components-templates')(vm)
+    templates: require('./partials/components-templates')(vm),
+    plugins: require('./partials/components-plugins')(vm)
   };
 
   const indexJS = require('./static/index');
@@ -20,7 +21,8 @@ module.exports = vm => {
   const extraLinks =
     ` | <a href="#components-history" class="tab-link">History</a>` +
     ` | <a href="#components-templates" class="tab-link">Available templates</a>` +
-    ` | <a href="#components-dependencies" class="tab-link">Available dependencies</a>`;
+    ` | <a href="#components-dependencies" class="tab-link">Available dependencies</a>` +
+    ` | <a href="#components-plugins" class="tab-link">Available plugins</a>`;
 
   const registryType = isLocal ? 'Local dev registry' : 'On-line registry';
 
@@ -40,7 +42,8 @@ module.exports = vm => {
     ${tabs.list}
     ${tabs.history}
     ${tabs.templates}
-    ${tabs.dependencies}`;
+    ${tabs.dependencies}
+    ${tabs.plugins}`;
 
   const scripts = `<script>
     var q = "${encodeURIComponent(vm.q)}", componentsList = ${JSON.stringify(

--- a/src/registry/views/partials/components-plugins.js
+++ b/src/registry/views/partials/components-plugins.js
@@ -1,16 +1,20 @@
 module.exports = vm => {
-  const pluginRow = name => `<div class="componentRow row table">
+  const pluginRow = ([
+    name,
+    description
+  ]) => `<div class="componentRow row table">
     <p class="release">
-      ${name}
+      <span style="font-weight: bold">${name +
+        (description ? ':' : '')}</span>${description}
     </p>
   </div>
 `;
 
-  const pluginNames = Object.keys(vm.availablePlugins);
+  const plugins = Object.entries(
+    vm.availablePlugins
+  ).map(([pluginName, fn]) => [pluginName, fn.toString()]);
 
   return `<div id="components-plugins" class="box">${
-    pluginNames.length
-      ? pluginNames.map(pluginRow).join('')
-      : 'No plugins registered'
+    plugins.length ? plugins.map(pluginRow).join('') : 'No plugins registered'
   }</div>`;
 };

--- a/src/registry/views/partials/components-plugins.js
+++ b/src/registry/views/partials/components-plugins.js
@@ -1,0 +1,16 @@
+module.exports = vm => {
+  const pluginRow = name => `<div class="componentRow row table">
+    <p class="release">
+      ${name}
+    </p>
+  </div>
+`;
+
+  const pluginNames = Object.keys(vm.availablePlugins);
+
+  return `<div id="components-plugins" class="box">${
+    pluginNames.length
+      ? pluginNames.map(pluginRow).join('')
+      : 'No plugins registered'
+  }</div>`;
+};

--- a/test/unit/registry-domain-plugins-initialiser.js
+++ b/test/unit/registry-domain-plugins-initialiser.js
@@ -104,6 +104,7 @@ describe('registry : domain : plugins-initialiser', () => {
       const plugins = [
         {
           name: 'getValue',
+          description: 'Function description',
           register: {
             register: (options, deps, cb) => {
               passedOptions = options;
@@ -140,6 +141,11 @@ describe('registry : domain : plugins-initialiser', () => {
     it('should expose the functionalities using the plugin names', () => {
       expect(result.getValue).to.be.a('function');
       expect(result.isFlagged).to.be.a('function');
+    });
+
+    it('should expose descriptions on the plugin functions if defined', () => {
+      expect(result.getValue.toString()).to.equal('Function description');
+      expect(result.isFlagged.toString()).to.equal('');
     });
 
     it('should be make the functionality usable', () => {

--- a/test/unit/registry-routes-plugins.js
+++ b/test/unit/registry-routes-plugins.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+describe('registry : routes : plugins', () => {
+  const PluginsRoute = require('../../src/registry/routes/plugins');
+  let resJsonStub, statusStub, pluginsRoute, plugins;
+
+  const initialise = function() {
+    resJsonStub = sinon.stub();
+    statusStub = sinon.stub().returns({ json: resJsonStub });
+    const plugin1 = () => {};
+    plugin1.toString = () => 'Description plugin 1';
+    const plugin2 = () => {};
+    plugin2.toString = () => '';
+    plugins = {
+      plugin1,
+      plugin2
+    };
+  };
+
+  describe('when is not discoverable', () => {
+    before(() => {
+      initialise();
+      const conf = {
+        plugins,
+        discovery: false
+      };
+      pluginsRoute = new PluginsRoute(conf);
+
+      pluginsRoute({ headers: {} }, { conf, status: statusStub });
+    });
+
+    it('should return 401 status code', () => {
+      expect(statusStub.args[0][0]).to.be.equal(401);
+    });
+  });
+
+  describe('when is discoverable', () => {
+    before(() => {
+      initialise();
+      const conf = {
+        plugins,
+        discovery: true
+      };
+      pluginsRoute = new PluginsRoute(conf);
+
+      pluginsRoute({ headers: {} }, { conf, status: statusStub });
+    });
+
+    it('should return the list of plugins', () => {
+      expect(resJsonStub.args[0][0]).to.eql([
+        { name: 'plugin1', description: 'Description plugin 1' },
+        { name: 'plugin2', description: '' }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #489 

Adds a view to see the list of available plugins on the UI. Adds an extra optional parameter when registering to add a description to your plugin. This could be improved a lot by having real schematic instructions of how your function works (injecting/analyzing JSDoc on your plugin?) but that could be a separate story.

Also, as mentioned in issue #512, added also a JSON Api endpoint that gives the metadata list, but only if your service is set as discoverable.