### PR TITLE
clean eslint rule warnings/errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -83,7 +83,7 @@
     "no-caller": "error",
     "no-catch-shadow": "off",
     "no-compare-neg-zero": "error",
-    "no-confusing-arrow": "error",
+    "no-confusing-arrow": "off",
     "no-continue": "off",
     "no-console": "warn",
     "no-div-regex": "error",

--- a/src/cli/domain/handle-dependencies/install-compiler.js
+++ b/src/cli/domain/handle-dependencies/install-compiler.js
@@ -8,13 +8,7 @@ const npm = require('../../../utils/npm-utils');
 const strings = require('../../../resources/index');
 
 module.exports = (options, cb) => {
-  const {
-    compilerPath,
-    componentName,
-    componentPath,
-    dependency,
-    logger
-  } = options;
+  const { compilerPath, componentPath, dependency, logger } = options;
 
   logger.warn(format(strings.messages.cli.INSTALLING_DEPS, dependency), true);
 

--- a/src/cli/domain/local.js
+++ b/src/cli/domain/local.js
@@ -37,7 +37,8 @@ module.exports = function() {
     },
     getComponentsByDir: getComponentsByDir(),
     init: function(options, callback) {
-      let { componentName, templateType, logger } = options;
+      const { componentName, logger } = options;
+      let { templateType } = options;
       if (!validator.validateComponentName(componentName)) {
         return callback('name not valid');
       }

--- a/src/cli/domain/package-components.js
+++ b/src/cli/domain/package-components.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const _ = require('lodash');
 
 const requireTemplate = require('./handle-dependencies/require-template');
 const validator = require('../../registry/domain/validators');
@@ -41,8 +40,6 @@ module.exports = function() {
       minify,
       verbose,
       production
-      // TODO: logger,
-      // TODO: watch,
     };
 
     try {

--- a/src/cli/facade/clean.js
+++ b/src/cli/facade/clean.js
@@ -29,7 +29,7 @@ module.exports = function(dependencies) {
     );
 
   const removeFolders = (list, cb) =>
-    remove(list, (err, result) => {
+    remove(list, err => {
       if (err) {
         logger.err(strings.errors.cli.cleanRemoveError(err));
         return cb(err);

--- a/src/cli/facade/package.js
+++ b/src/cli/facade/package.js
@@ -25,7 +25,7 @@ module.exports = function(dependencies) {
         logger,
         useComponentDependencies
       },
-      (err, dependencies) => {
+      err => {
         if (err) {
           logger.err(err);
           return callback(err);

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -3,6 +3,7 @@
 const colors = require('colors/safe');
 
 const logger = {
+  // eslint-disable-next-line no-console
   writeLn: console.log,
   write: msg => process.stdout.write(msg.toString())
 };

--- a/src/registry/domain/validators/index.js
+++ b/src/registry/domain/validators/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const semver = require('semver');
-const _ = require('lodash');
 
 const ocCliVersionValidator = require('./oc-cli-version');
 const componentParametersValidator = require('./component-parameters');

--- a/src/registry/middleware/index.js
+++ b/src/registry/middleware/index.js
@@ -3,15 +3,14 @@
 const bodyParser = require('body-parser');
 const errorhandler = require('errorhandler');
 const morgan = require('morgan');
-const path = require('path');
 
 const baseUrlHandler = require('./base-url-handler');
 const cors = require('./cors');
 const discoveryHandler = require('./discovery-handler');
 const fileUploads = require('./file-uploads');
 const requestHandler = require('./request-handler');
-const bodyParserJsonArgument = {inflate: true};
-const bodyParserUrlEncodedArgument = {extended: true};
+const bodyParserJsonArgument = { inflate: true };
+const bodyParserUrlEncodedArgument = { extended: true };
 
 module.exports.bind = function(app, options) {
   app.set('port', options.port);
@@ -25,8 +24,8 @@ module.exports.bind = function(app, options) {
   app.use(requestHandler());
 
   if (options.postRequestPayloadSize) {
-      bodyParserJsonArgument.limit = options.postRequestPayloadSize;
-      bodyParserUrlEncodedArgument.limit = options.postRequestPayloadSize;
+    bodyParserJsonArgument.limit = options.postRequestPayloadSize;
+    bodyParserUrlEncodedArgument.limit = options.postRequestPayloadSize;
   }
 
   app.use(bodyParser.json(bodyParserJsonArgument));

--- a/src/registry/routes/static-redirector.js
+++ b/src/registry/routes/static-redirector.js
@@ -46,7 +46,7 @@ module.exports = function(repository) {
       res.errorDetails = `File ${filePath} not found`;
       return res.status(404).json({ err: res.errorDetails });
     }
-    
+
     const stats = fs.statSync(filePath);
     if (stats.isDirectory()) {
       res.errorDetails = 'Forbidden: Directory Listing Denied';

--- a/src/registry/views/partials/layout.js
+++ b/src/registry/views/partials/layout.js
@@ -1,6 +1,6 @@
 const styleCSS = require('../static/style');
 
-module.exports = vm => ({ content, head, scripts }) => {
+module.exports = vm => ({ content, scripts }) => {
   const href = vm.href.replace('http://', '//').replace('https://', '//');
 
   return `<!DOCTYPE html><html>

--- a/tasks/logger.js
+++ b/tasks/logger.js
@@ -5,6 +5,7 @@ const nodeEmoji = require('node-emoji');
 
 const log = (col, style, emoji) =>
   function(msg) {
+    // eslint-disable-next-line no-console
     console.log(
       chalk[style][col](msg) + (emoji ? ` ${nodeEmoji.get(emoji)}` : '')
     );

--- a/test/unit/cli-domain-clean.js
+++ b/test/unit/cli-domain-clean.js
@@ -40,15 +40,14 @@ describe('cli : domain : clean', () => {
     });
 
     describe('getComponentsByDir error', () => {
-      let error, result;
+      let error;
       beforeEach(done => {
         const clean = initialize({
           getComponentsByDirError: new Error('oops')
         });
 
-        clean.fetchList('my-components-folder', (err, res) => {
+        clean.fetchList('my-components-folder', err => {
           error = err;
-          result = res;
           done();
         });
       });
@@ -60,13 +59,12 @@ describe('cli : domain : clean', () => {
 
   describe('when removing the folders to clean', () => {
     describe('happy path', () => {
-      let error, result, removeMock;
+      let error, removeMock;
       beforeEach(done => {
         removeMock = sinon.stub().yields(null, 'ok');
         const clean = initialize({ removeMock });
-        clean.remove(['path/to/my-component1/node_modules'], (err, res) => {
+        clean.remove(['path/to/my-component1/node_modules'], err => {
           error = err;
-          result = res;
           done();
         });
       });
@@ -82,13 +80,12 @@ describe('cli : domain : clean', () => {
     });
 
     describe('fs.remove error', () => {
-      let error, result, removeMock;
+      let error, removeMock;
       beforeEach(done => {
         removeMock = sinon.stub().yields(new Error('nope'));
         const clean = initialize({ removeMock });
-        clean.remove(['path/to/my-component1/node_modules'], (err, res) => {
+        clean.remove(['path/to/my-component1/node_modules'], err => {
           error = err;
-          result = res;
           done();
         });
       });

--- a/test/unit/cli-domain-handle-dependencies-ensure-compiler-is-declared-as-devDependency.js
+++ b/test/unit/cli-domain-handle-dependencies-ensure-compiler-is-declared-as-devDependency.js
@@ -35,7 +35,7 @@ describe('cli : domain : handle-dependencies : ensure-compiler-is-declared-as-de
   });
 
   describe('when compiler is not declared as devDependency', () => {
-    let error, result;
+    let error;
     beforeEach(done => {
       ensure(
         {
@@ -45,9 +45,8 @@ describe('cli : domain : handle-dependencies : ensure-compiler-is-declared-as-de
           },
           template: 'oc-template-react'
         },
-        (err, compilerDep) => {
+        err => {
           error = err;
-          result = compilerDep;
           done();
         }
       );

--- a/test/unit/cli-domain-handle-dependencies-get-compiler.js
+++ b/test/unit/cli-domain-handle-dependencies-get-compiler.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const _ = require('lodash');
 
 describe('cli : domain : handle-dependencies : get-compiler', () => {
-  let cleanRequireStub, error, installCompilerStub, result;
+  let cleanRequireStub, error, installCompilerStub;
   const execute = (opts, done) => {
     done = done || opts;
     const compilerVersion = opts.compilerVersionEmpty ? '' : '1.2.3';
@@ -31,9 +31,8 @@ describe('cli : domain : handle-dependencies : get-compiler', () => {
       }
     );
 
-    getCompiler(_.cloneDeep(options), (err, res) => {
+    getCompiler(_.cloneDeep(options), err => {
       error = err;
-      result = res;
       done();
     });
   };

--- a/test/unit/cli-domain-handle-dependencies-require-template.js
+++ b/test/unit/cli-domain-handle-dependencies-require-template.js
@@ -3,11 +3,8 @@
 const expect = require('chai').expect;
 const injectr = require('injectr');
 const sinon = require('sinon');
-const _ = require('lodash');
 
 describe('cli : domain : handle-dependencies : require-template', () => {
-  const isTemplateValid = sinon.stub().returns(true);
-
   let result, error;
   const execute = options => {
     error = null;

--- a/test/unit/cli-domain-package-components.js
+++ b/test/unit/cli-domain-package-components.js
@@ -2,9 +2,7 @@
 
 const expect = require('chai').expect;
 const injectr = require('injectr');
-const path = require('path');
 const sinon = require('sinon');
-const _ = require('lodash');
 
 describe('cli : domain : package-components', () => {
   const initialise = function(componentName) {

--- a/test/unit/cli-facade-clean.js
+++ b/test/unit/cli-facade-clean.js
@@ -7,7 +7,7 @@ const sinon = require('sinon');
 describe('cli : facade : clean', () => {
   const logSpy = {};
 
-  let error, result, readMock;
+  let readMock;
   const execute = (options, done) => {
     logSpy.ok = sinon.spy();
     logSpy.err = sinon.spy();
@@ -27,9 +27,7 @@ describe('cli : facade : clean', () => {
     });
 
     const cleanFacade = new CleanFacade({ local, logger: logSpy });
-    cleanFacade(options.params, (err, res) => {
-      error = err;
-      result = res;
+    cleanFacade(options.params, () => {
       done();
     });
   };

--- a/test/unit/registry-domain-register-templates.js
+++ b/test/unit/registry-domain-register-templates.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const expect = require('chai').expect;
-const injectr = require('injectr');
-const sinon = require('sinon');
 
 describe('registry : domain : register-templates', () => {
   const registerTemplates = require('../../src/registry/domain/register-templates.js');

--- a/test/unit/utils-npm-utils.js
+++ b/test/unit/utils-npm-utils.js
@@ -37,7 +37,7 @@ describe('utils : npm-utils', () => {
           onStub = sinon.stub();
           crossSpawnStub.reset();
           crossSpawnStub.returns({ on: onStub });
-          npmUtils.init(scenario.input, (err, res) => {
+          npmUtils.init(scenario.input, err => {
             error = err;
             done();
           });


### PR DESCRIPTION
This is just a cleanup of code following eslint errors/warnings present. Some notes:

1. There's still two warnings about use of console. I left them since I'm not sure if they are a problem or not (they were two more but those I added an exception rule since they are on `logger` files, so makes sense they reference console.log)
2. I disabled `no-confusing-arrow`. Trying to refactor it would conflict with the also enabled rule `arrow-body-style` to not have a body where you only return, so I decided to remove the first one since there's not a lot of cases anyways.
3. I removed two TODO (per eslint rule) about adding `logger` and `watch` to the compiler, but added and issue about it (not going to reference it so it doesn't get closed when merging this)