### PR TITLE
Drop support for Node 8/10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: node_js
 
 matrix:
   include:
-    - node_js: "8"
-    - node_js: "9"
-    - node_js: "10"
     - node_js: "12"
+    - node_js: "14"
+    - node_js: "16"
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ version: "{build}"
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 8
+    - nodejs_version: 12
 
 # Get the stable version of node
 install:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node 8/10 are [out of support](https://nodejs.org/en/about/releases/), and even the last versions of our test libraries have [dropped them](https://github.com/mochajs/mocha/pull/4633), so let's drop them.