### PR TITLE
sanitise templates and pollinginterval options

### DIFF
--- a/src/registry/domain/options-sanitiser.js
+++ b/src/registry/domain/options-sanitiser.js
@@ -7,7 +7,7 @@ const auth = require('./authentication');
 
 const DEFAULT_NODE_KEEPALIVE_MS = 5000;
 
-module.exports = function(input) {
+module.exports = function (input) {
   const options = _.clone(input);
 
   if (!options.publishAuth) {
@@ -45,6 +45,14 @@ module.exports = function(input) {
 
   if (_.isUndefined(options.discovery)) {
     options.discovery = true;
+  }
+
+  if (_.isUndefined(options.pollingInterval)) {
+    options.pollingInterval = 5;
+  }
+
+  if (_.isUndefined(options.templates)) {
+    options.templates = [];
   }
 
   if (

--- a/test/unit/registry-domain-options-sanitiser.js
+++ b/test/unit/registry-domain-options-sanitiser.js
@@ -121,6 +121,22 @@ describe('registry : domain : options-sanitiser', () => {
     });
   });
 
+  describe('when pollingInterval', () => {
+    describe('is provided', () => {
+      const options = { baseUrl: 'dummy', pollingInterval: 10 };
+      it('should not modify it', () => {
+        expect(sanitise(options).pollingInterval).to.deep.equal(10);
+      });
+    });
+
+    describe('is not provided', () => {
+      const options = { baseUrl: 'dummy' };
+      it('should initialize it as 5000', () => {
+        expect(sanitise(options).pollingInterval).to.deep.equal(5);
+      });
+    });
+  });
+
   describe('when env', () => {
     describe('is provided', () => {
       const options = { baseUrl: 'dummy', env: { value: 'test' } };

--- a/test/unit/registry-domain-options-sanitiser.js
+++ b/test/unit/registry-domain-options-sanitiser.js
@@ -137,6 +137,22 @@ describe('registry : domain : options-sanitiser', () => {
     });
   });
 
+  describe('when templates', () => {
+    describe('is provided', () => {
+      const options = { baseUrl: 'dummy', templates: [{ name: 'hi' }] };
+      it('should not modify it', () => {
+        expect(sanitise(options).templates).to.deep.equal([{ name: 'hi' }]);
+      });
+    });
+
+    describe('is not provided', () => {
+      const options = { baseUrl: 'dummy' };
+      it('should initialize it as 5000', () => {
+        expect(sanitise(options).templates).to.deep.equal([]);
+      });
+    });
+  });
+
   describe('when env', () => {
     describe('is provided', () => {
       const options = { baseUrl: 'dummy', env: { value: 'test' } };


### PR DESCRIPTION
pollingInterval according to the wiki is an optional config option with a default of 5 seconds, but it wasn't defaulted, so I'm adding it.
Also I'm sanitising templates to default to empty array, because right now it relies on the fact that lodash method `union` will accept undefined as a parameter (and do a union as if with an empty array), but I think it's safer to have it as empty array from the get-go.