### PR TITLE
remove stringformat

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "semver": "6.3.0",
     "semver-extra": "3.0.0",
     "serialize-error": "4.1.0",
-    "stringformat": "0.0.5",
     "targz": "1.0.1",
     "try-require": "^1.2.1",
     "yargs": "13.3.0"

--- a/src/cli/domain/handle-dependencies/ensure-compiler-is-declared-as-devDependency.js
+++ b/src/cli/domain/handle-dependencies/ensure-compiler-is-declared-as-devDependency.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
-
 const strings = require('../../../resources');
 
 module.exports = (options, cb) => {
@@ -11,7 +9,7 @@ module.exports = (options, cb) => {
 
   const err = isOk
     ? null
-    : format(strings.errors.cli.TEMPLATE_DEP_MISSING, template, componentPath);
+    : strings.errors.cli.TEMPLATE_DEP_MISSING(template, componentPath);
 
   cb(err, compilerDep);
 };

--- a/src/cli/domain/handle-dependencies/install-compiler.js
+++ b/src/cli/domain/handle-dependencies/install-compiler.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
-
 const cleanRequire = require('../../../utils/clean-require');
 const isTemplateValid = require('../../../utils/is-template-valid');
 const npm = require('../../../utils/npm-utils');
@@ -10,7 +8,7 @@ const strings = require('../../../resources/index');
 module.exports = (options, cb) => {
   const { compilerPath, componentPath, dependency, logger } = options;
 
-  logger.warn(format(strings.messages.cli.INSTALLING_DEPS, dependency), true);
+  logger.warn(strings.messages.cli.INSTALLING_DEPS(dependency), true);
 
   const npmOptions = {
     dependency,

--- a/src/cli/domain/handle-dependencies/install-missing-dependencies.js
+++ b/src/cli/domain/handle-dependencies/install-missing-dependencies.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const path = require('path');
 const _ = require('lodash');
 
@@ -17,10 +16,7 @@ module.exports = (options, callback) => {
     return callback(null);
   }
 
-  logger.warn(
-    format(strings.messages.cli.INSTALLING_DEPS, missing.join(', ')),
-    true
-  );
+  logger.warn(strings.messages.cli.INSTALLING_DEPS(missing.join(', ')), true);
 
   const npmOptions = {
     dependencies: missing,

--- a/src/cli/domain/handle-dependencies/link-missing-dependencies.js
+++ b/src/cli/domain/handle-dependencies/link-missing-dependencies.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const _ = require('lodash');
 const path = require('path');
 const fs = require('fs-extra');
@@ -18,10 +17,7 @@ module.exports = (options, callback) => {
   }
 
   logger.warn(
-    format(
-      strings.messages.cli.LINKING_DEPENDENCIES,
-      missingDependencies.join(', ')
-    ),
+    strings.messages.cli.LINKING_DEPENDENCIES(missingDependencies.join(', ')),
     true
   );
 
@@ -39,9 +35,7 @@ module.exports = (options, callback) => {
       fs.ensureSymlinkSync(pathToComponentModule, pathToModule, symLinkType);
     } catch (err) {
       symLinkError = true;
-      logger.err(
-        format(strings.errors.cli.DEPENDENCY_LINK_FAIL, moduleName, err)
-      );
+      logger.err(strings.errors.cli.DEPENDENCY_LINK_FAIL(moduleName, err));
     }
   });
   return !symLinkError

--- a/src/cli/domain/handle-dependencies/require-template.js
+++ b/src/cli/domain/handle-dependencies/require-template.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const path = require('path');
 
 const cleanRequire = require('../../../utils/clean-require');
@@ -35,13 +34,11 @@ module.exports = function(template, options) {
   );
 
   if (!ocTemplate) {
-    throw new Error(format(strings.errors.cli.TEMPLATE_NOT_FOUND, template));
+    throw new Error(strings.errors.cli.TEMPLATE_NOT_FOUND(template));
   }
 
   if (!isTemplateValid(ocTemplate, requireOptions)) {
-    throw new Error(
-      format(strings.errors.cli.TEMPLATE_TYPE_NOT_VALID, template)
-    );
+    throw new Error(strings.errors.cli.TEMPLATE_TYPE_NOT_VALID(template));
   }
 
   return ocTemplate;

--- a/src/cli/facade/clean.js
+++ b/src/cli/facade/clean.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const read = require('read');
 
 const strings = require('../../resources/index');
@@ -44,7 +43,7 @@ module.exports = function(dependencies) {
 
     fetchList(opts.dirPath, (err, list) => {
       if (err) {
-        logger.err(format(strings.errors.generic, err));
+        logger.err(strings.errors.generic(err));
         return callback(err);
       }
 

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -2,7 +2,6 @@
 
 const async = require('async');
 const colors = require('colors/safe');
-const format = require('stringformat');
 const getPort = require('getport');
 const livereload = require('livereload');
 const path = require('path');
@@ -36,9 +35,9 @@ module.exports = function(dependencies) {
     const watchForChanges = function({ components, refreshLiveReload }, cb) {
       watch(components, componentsDir, (err, changedFile, componentDir) => {
         if (err) {
-          logger.err(format(strings.errors.generic, err));
+          logger.err(strings.errors.generic(err));
         } else {
-          logger.warn(format(cliMessages.CHANGES_DETECTED, changedFile));
+          logger.warn(cliMessages.CHANGES_DETECTED(changedFile));
           if (!hotReloading) {
             logger.warn(cliMessages.HOT_RELOADING_DISABLED);
           } else if (!componentDir) {
@@ -81,11 +80,7 @@ module.exports = function(dependencies) {
                   ? error.message
                   : error;
               logger.err(
-                format(
-                  cliErrors.PACKAGING_FAIL,
-                  componentsDirs[i],
-                  errorDescription
-                )
+                cliErrors.PACKAGING_FAIL(componentsDirs[i], errorDescription)
               );
               logger.warn(cliMessages.RETRYING_10_SECONDS);
               setTimeout(() => {
@@ -109,8 +104,7 @@ module.exports = function(dependencies) {
       registry.on('request', data => {
         if (data.errorCode === 'PLUGIN_MISSING_FROM_REGISTRY') {
           logger.err(
-            format(
-              cliErrors.PLUGIN_MISSING_FROM_REGISTRY,
+            cliErrors.PLUGIN_MISSING_FROM_REGISTRY(
               data.errorDetails,
               colors.blue(strings.commands.cli.MOCK_PLUGIN)
             )
@@ -122,7 +116,7 @@ module.exports = function(dependencies) {
     logger.warn(cliMessages.SCANNING_COMPONENTS, true);
     local.getComponentsByDir(componentsDir, (err, components) => {
       if (_.isEmpty(components)) {
-        err = format(cliErrors.DEV_FAIL, cliErrors.COMPONENTS_NOT_FOUND);
+        err = cliErrors.DEV_FAIL(cliErrors.COMPONENTS_NOT_FOUND);
         callback(err);
         return logger.err(err);
       }
@@ -181,19 +175,16 @@ module.exports = function(dependencies) {
 
               registerPlugins(registry);
 
-              logger.warn(format(cliMessages.REGISTRY_STARTING, baseUrl));
+              logger.warn(cliMessages.REGISTRY_STARTING(baseUrl));
               if (liveReload.port) {
                 logger.warn(
-                  format(
-                    cliMessages.REGISTRY_LIVERELOAD_STARTING,
-                    liveReload.port
-                  )
+                  cliMessages.REGISTRY_LIVERELOAD_STARTING(liveReload.port)
                 );
               }
               registry.start(err => {
                 if (err) {
                   if (err.code === 'EADDRINUSE') {
-                    err = format(cliErrors.PORT_IS_BUSY, port);
+                    err = cliErrors.PORT_IS_BUSY(port);
                   }
 
                   logger.err(err);

--- a/src/cli/facade/init.js
+++ b/src/cli/facade/init.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const path = require('path');
 const _ = require('lodash');
 
@@ -35,9 +34,9 @@ module.exports = function(dependencies) {
           }
 
           if (err === 'template type not valid') {
-            err = format(errors.TEMPLATE_TYPE_NOT_VALID, templateType);
+            err = errors.TEMPLATE_TYPE_NOT_VALID(templateType);
           }
-          logger.err(format(errors.INIT_FAIL, err));
+          logger.err(errors.INIT_FAIL(err));
         } else {
           logger.log(messages.initSuccess(componentName, componentPath));
         }

--- a/src/cli/facade/mock.js
+++ b/src/cli/facade/mock.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
-
 const strings = require('../../resources/index');
 const wrapCliCallback = require('../wrap-cli-callback');
 
@@ -14,11 +12,7 @@ module.exports = function(dependencies) {
 
     local.mock(opts, (err, res) => {
       logger.ok(
-        format(
-          strings.messages.cli.MOCKED_PLUGIN,
-          opts.targetName,
-          opts.targetValue
-        )
+        strings.messages.cli.MOCKED_PLUGIN(opts.targetName, opts.targetValue)
       );
       callback(err, res);
     });

--- a/src/cli/facade/package.js
+++ b/src/cli/facade/package.js
@@ -2,7 +2,6 @@
 
 const strings = require('../../resources/index');
 const wrapCliCallback = require('../wrap-cli-callback');
-const format = require('stringformat');
 const path = require('path');
 const handleDependencies = require('../domain/handle-dependencies');
 
@@ -18,7 +17,7 @@ module.exports = function(dependencies) {
 
     callback = wrapCliCallback(callback);
 
-    logger.warn(format(strings.messages.cli.PACKAGING, packageDir));
+    logger.warn(strings.messages.cli.PACKAGING(packageDir));
     handleDependencies(
       {
         components: [path.resolve(componentPath)],
@@ -36,27 +35,23 @@ module.exports = function(dependencies) {
         };
         local.package(packageOptions, (err, component) => {
           if (err) {
-            logger.err(format(strings.errors.cli.PACKAGE_CREATION_FAIL, err));
+            logger.err(strings.errors.cli.PACKAGE_CREATION_FAIL(err));
             return callback(err);
           }
 
-          logger.ok(format(strings.messages.cli.PACKAGED, packageDir));
+          logger.ok(strings.messages.cli.PACKAGED(packageDir));
 
           if (opts.compress) {
             logger.warn(
-              format(strings.messages.cli.COMPRESSING, compressedPackagePath)
+              strings.messages.cli.COMPRESSING(compressedPackagePath)
             );
 
             local.compress(packageDir, compressedPackagePath, err => {
               if (err) {
-                logger.err(
-                  format(strings.errors.cli.PACKAGE_CREATION_FAIL, err)
-                );
+                logger.err(strings.errors.cli.PACKAGE_CREATION_FAIL(err));
                 return callback(err);
               }
-              logger.ok(
-                format(strings.messages.cli.COMPRESSED, compressedPackagePath)
-              );
+              logger.ok(strings.messages.cli.COMPRESSED(compressedPackagePath));
               callback(null, component);
             });
           } else {

--- a/src/cli/facade/publish.js
+++ b/src/cli/facade/publish.js
@@ -2,7 +2,6 @@
 
 const async = require('async');
 const colors = require('colors/safe');
-const format = require('stringformat');
 const path = require('path');
 const fs = require('fs-extra');
 const read = require('read');
@@ -52,7 +51,7 @@ module.exports = function(dependencies) {
     };
 
     const packageAndCompress = function(cb) {
-      logger.warn(format(strings.messages.cli.PACKAGING, packageDir));
+      logger.warn(strings.messages.cli.PACKAGING(packageDir));
       const packageOptions = {
         production: true,
         componentPath: path.resolve(componentPath)
@@ -63,9 +62,7 @@ module.exports = function(dependencies) {
           return cb(err);
         }
 
-        logger.warn(
-          format(strings.messages.cli.COMPRESSING, compressedPackagePath)
-        );
+        logger.warn(strings.messages.cli.COMPRESSING(compressedPackagePath));
 
         compress(err => {
           if (err) {
@@ -77,15 +74,14 @@ module.exports = function(dependencies) {
     };
 
     const putComponentToRegistry = function(options, cb) {
-      logger.warn(format(strings.messages.cli.PUBLISHING, options.route));
+      logger.warn(strings.messages.cli.PUBLISHING(options.route));
 
       registry.putComponent(options, err => {
         if (err) {
           if (err === 'Unauthorized') {
             if (!!options.username || !!options.password) {
               logger.err(
-                format(
-                  strings.errors.cli.PUBLISHING_FAIL,
+                strings.errors.cli.PUBLISHING_FAIL(
                   strings.errors.cli.INVALID_CREDENTIALS
                 )
               );
@@ -98,28 +94,22 @@ module.exports = function(dependencies) {
               putComponentToRegistry(_.extend(options, credentials), cb);
             });
           } else if (err.code === 'cli_version_not_valid') {
-            const upgradeCommand = format(
-                strings.commands.cli.UPGRADE,
+            const upgradeCommand = strings.commands.cli.UPGRADE(
                 err.details.suggestedVersion
               ),
-              errorDetails = format(
-                strings.errors.cli.OC_CLI_VERSION_NEEDS_UPGRADE,
+              errorDetails = strings.errors.cli.OC_CLI_VERSION_NEEDS_UPGRADE(
                 colors.blue(upgradeCommand)
               );
 
-            errorMessage = format(
-              strings.errors.cli.PUBLISHING_FAIL,
-              errorDetails
-            );
+            errorMessage = strings.errors.cli.PUBLISHING_FAIL(errorDetails);
             logger.err(errorMessage);
             return cb(errorMessage);
           } else if (err.code === 'node_version_not_valid') {
-            const details = format(
-              strings.errors.cli.NODE_CLI_VERSION_NEEDS_UPGRADE,
+            const details = strings.errors.cli.NODE_CLI_VERSION_NEEDS_UPGRADE(
               err.details.suggestedVersion
             );
 
-            errorMessage = format(strings.errors.cli.PUBLISHING_FAIL, details);
+            errorMessage = strings.errors.cli.PUBLISHING_FAIL(details);
             logger.err(errorMessage);
             return cb(errorMessage);
           } else {
@@ -128,12 +118,12 @@ module.exports = function(dependencies) {
                 err = JSON.stringify(err);
               } catch (er) {}
             }
-            errorMessage = format(strings.errors.cli.PUBLISHING_FAIL, err);
+            errorMessage = strings.errors.cli.PUBLISHING_FAIL(err);
             logger.err(errorMessage);
             return cb(errorMessage);
           }
         } else {
-          logger.ok(format(strings.messages.cli.PUBLISHED, options.route));
+          logger.ok(strings.messages.cli.PUBLISHED(options.route));
           return cb(null, 'ok');
         }
       });
@@ -177,10 +167,7 @@ module.exports = function(dependencies) {
             }
             packageAndCompress((err, component) => {
               if (err) {
-                errorMessage = format(
-                  strings.errors.cli.PACKAGE_CREATION_FAIL,
-                  err
-                );
+                errorMessage = strings.errors.cli.PACKAGE_CREATION_FAIL(err);
                 logger.err(errorMessage);
                 return callback(errorMessage);
               }

--- a/src/cli/facade/registry-ls.js
+++ b/src/cli/facade/registry-ls.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const _ = require('lodash');
 
 const strings = require('../../resources/index');
@@ -15,7 +14,7 @@ module.exports = function(dependencies) {
 
     registry.get((err, registries) => {
       if (err) {
-        logger.err(format(strings.errors.generic, err));
+        logger.err(strings.errors.generic(err));
         return callback(err);
       } else {
         logger.warn(strings.messages.cli.REGISTRY_LIST);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -2,7 +2,6 @@
 
 const cli = require('yargs');
 const commands = require('./commands');
-const format = require('stringformat');
 const semver = require('semver');
 const _ = require('lodash');
 
@@ -16,8 +15,7 @@ const currentNodeVersion = process.version;
 const minSupportedVersion = '6.0.0';
 if (semver.lt(currentNodeVersion, minSupportedVersion)) {
   logger.err(
-    format(
-      strings.errors.cli.NODE_CLI_VERSION_UNSUPPORTED,
+    strings.errors.cli.NODE_CLI_VERSION_UNSUPPORTED(
       currentNodeVersion,
       minSupportedVersion
     )

--- a/src/cli/validate-command.js
+++ b/src/cli/validate-command.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const format = require('stringformat');
 const commands = require('./commands');
 const strings = require('../resources');
 
@@ -12,9 +11,7 @@ const validateCommand = (argv, level) => {
   }
 
   if (argv._.length > level && !_.includes(keys, argv._[level])) {
-    throw new Error(
-      format(strings.messages.cli.NO_SUCH_COMMAND, argv._[level])
-    );
+    throw new Error(strings.messages.cli.NO_SUCH_COMMAND(argv._[level]));
   }
   return true;
 };

--- a/src/registry/domain/authentication.js
+++ b/src/registry/domain/authentication.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const basicAuth = require('basic-auth-connect');
-const format = require('stringformat');
 const path = require('path');
 
 const strings = require('../../resources/');
@@ -40,8 +39,7 @@ module.exports.validate = function(authConfig) {
     } catch (err) {
       return {
         isValid: false,
-        message: format(
-          strings.errors.registry.CONFIGURATION_PUBLISH_AUTH_MODULE_NOT_FOUND,
+        message: strings.errors.registry.CONFIGURATION_PUBLISH_AUTH_MODULE_NOT_FOUND(
           moduleName
         )
       };

--- a/src/registry/domain/plugins-initialiser.js
+++ b/src/registry/domain/plugins-initialiser.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const async = require('async');
-const format = require('stringformat');
 const _ = require('lodash');
 const DepGraph = require('dependency-graph').DepGraph;
 
@@ -19,7 +18,7 @@ const validatePlugins = function(plugins) {
       !_.isString(plugin.name)
     ) {
       throw new Error(
-        format(strings.errors.registry.PLUGIN_NOT_VALID, plugin.name || c)
+        strings.errors.registry.PLUGIN_NOT_VALID(plugin.name || c)
       );
     }
   });

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const fs = require('fs-extra');
 const getUnixUtcTimestamp = require('oc-get-unix-utc-timestamp');
 const path = require('path');
@@ -73,8 +72,7 @@ module.exports = function(conf) {
 
       if (!_.includes(local.getComponents(), componentName)) {
         return callback(
-          format(
-            strings.errors.registry.COMPONENT_NOT_FOUND,
+          strings.errors.registry.COMPONENT_NOT_FOUND(
             componentName,
             repositorySource
           )
@@ -128,8 +126,7 @@ module.exports = function(conf) {
 
         if (allVersions.length === 0) {
           return callback(
-            format(
-              strings.errors.registry.COMPONENT_NOT_FOUND,
+            strings.errors.registry.COMPONENT_NOT_FOUND(
               componentName,
               repositorySource
             )
@@ -143,8 +140,7 @@ module.exports = function(conf) {
 
         if (!version) {
           return callback(
-            format(
-              strings.errors.registry.COMPONENT_VERSION_NOT_FOUND,
+            strings.errors.registry.COMPONENT_VERSION_NOT_FOUND(
               componentName,
               componentVersion,
               repositorySource
@@ -306,8 +302,7 @@ module.exports = function(conf) {
       if (!validator.validateVersion(componentVersion)) {
         return callback({
           code: strings.errors.registry.COMPONENT_VERSION_NOT_VALID_CODE,
-          msg: format(
-            strings.errors.registry.COMPONENT_VERSION_NOT_VALID,
+          msg: strings.errors.registry.COMPONENT_VERSION_NOT_VALID(
             componentVersion
           )
         });
@@ -323,8 +318,7 @@ module.exports = function(conf) {
       if (!validationResult.isValid) {
         return callback({
           code: strings.errors.registry.COMPONENT_PUBLISHVALIDATION_FAIL_CODE,
-          msg: format(
-            strings.errors.registry.COMPONENT_PUBLISHVALIDATION_FAIL,
+          msg: strings.errors.registry.COMPONENT_PUBLISHVALIDATION_FAIL(
             validationResult.error
           )
         });
@@ -342,8 +336,7 @@ module.exports = function(conf) {
             return callback({
               code:
                 strings.errors.registry.COMPONENT_VERSION_ALREADY_FOUND_CODE,
-              msg: format(
-                strings.errors.registry.COMPONENT_VERSION_ALREADY_FOUND,
+              msg: strings.errors.registry.COMPONENT_VERSION_ALREADY_FOUND(
                 componentName,
                 componentVersion,
                 repositorySource

--- a/src/registry/domain/validators/component-parameters.js
+++ b/src/registry/domain/validators/component-parameters.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const _ = require('lodash');
 
 const strings = require('../../../resources');
@@ -81,8 +80,7 @@ module.exports = function(requestParameters, expectedParameters) {
         .join('')
         .slice(0, -2);
 
-      errorString += format(
-        strings.errors.registry.MANDATORY_PARAMETER_MISSING,
+      errorString += strings.errors.registry.MANDATORY_PARAMETER_MISSING(
         missingParams
       );
     }
@@ -99,10 +97,7 @@ module.exports = function(requestParameters, expectedParameters) {
         .join('')
         .slice(0, -2);
 
-      errorString += format(
-        strings.errors.registry.PARAMETER_WRONG_FORMAT,
-        badParams
-      );
+      errorString += strings.errors.registry.PARAMETER_WRONG_FORMAT(badParams);
     }
     return errorString;
   })();

--- a/src/registry/domain/validators/registry-configuration.js
+++ b/src/registry/domain/validators/registry-configuration.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const _ = require('lodash');
 
 const auth = require('../authentication');
@@ -74,8 +73,7 @@ module.exports = function(conf) {
 
       if (route.route.indexOf(prefix) === 0) {
         return returnError(
-          format(
-            strings.errors.registry.CONFIGURATION_ROUTES_ROUTE_CONTAINS_PREFIX,
+          strings.errors.registry.CONFIGURATION_ROUTES_ROUTE_CONTAINS_PREFIX(
             prefix
           )
         );
@@ -94,7 +92,7 @@ module.exports = function(conf) {
       (!conf.s3.key && conf.s3.secret)
     ) {
       return returnError(
-        format(strings.errors.registry.CONFIGURATION_STORAGE_NOT_VALID, 'S3')
+        strings.errors.registry.CONFIGURATION_STORAGE_NOT_VALID('S3')
       );
     }
   }
@@ -113,8 +111,7 @@ module.exports = function(conf) {
         (!conf.storage.options.key && conf.storage.options.secret)
       ) {
         return returnError(
-          format(
-            strings.errors.registry.CONFIGURATION_STORAGE_NOT_VALID,
+          strings.errors.registry.CONFIGURATION_STORAGE_NOT_VALID(
             conf.storage.adapterType.toUpperCase()
           )
         );

--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
 const serializeError = require('serialize-error');
 const _ = require('lodash');
 
@@ -37,8 +36,7 @@ module.exports = function(conf, repository) {
         } catch (e) {
           res.status(500).json({
             code: 'RENDER_ERROR',
-            error: format(
-              strings.errors.registry.RENDER_ERROR,
+            error: strings.errors.registry.RENDER_ERROR(
               `${result.response.name}@${result.response.version}`,
               e.toString()
             )

--- a/src/registry/routes/components.js
+++ b/src/registry/routes/components.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const async = require('async');
-const format = require('stringformat');
 const _ = require('lodash');
 
 const GetComponentHelper = require('./helpers/get-component');
@@ -23,7 +22,7 @@ module.exports = function(conf, repository) {
     const returnError = function(message) {
       return res.status(400).json({
         code: registryErrors.BATCH_ROUTE_BODY_NOT_VALID_CODE,
-        error: format(registryErrors.BATCH_ROUTE_BODY_NOT_VALID, message)
+        error: registryErrors.BATCH_ROUTE_BODY_NOT_VALID(message)
       });
     };
 
@@ -39,10 +38,7 @@ module.exports = function(conf, repository) {
       const errors = _.compact(
         _.map(components, (component, index) => {
           if (!component.name) {
-            return format(
-              registryErrors.BATCH_ROUTE_COMPONENT_NAME_MISSING,
-              index
-            );
+            return registryErrors.BATCH_ROUTE_COMPONENT_NAME_MISSING(index);
           }
         })
       );
@@ -77,8 +73,7 @@ module.exports = function(conf, repository) {
           } else {
             res.status(500).json({
               code: 'RENDER_ERROR',
-              error: format(
-                strings.errors.registry.RENDER_ERROR,
+              error: strings.errors.registry.RENDER_ERROR(
                 results
                   .map(x => `${x.response.name}@${x.response.version}`)
                   .join(', '),

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -4,7 +4,6 @@ const acceptLanguageParser = require('accept-language-parser');
 const Cache = require('nice-cache');
 const Client = require('oc-client');
 const Domain = require('domain');
-const format = require('stringformat');
 const emptyResponseHandler = require('oc-empty-response-handler');
 const vm = require('vm');
 const _ = require('lodash');
@@ -113,8 +112,7 @@ module.exports = function(conf, repository) {
             status: 501,
             response: {
               code: 'PLUGIN_MISSING_FROM_REGISTRY',
-              error: format(
-                strings.errors.registry.PLUGIN_NOT_IMPLEMENTED,
+              error: strings.errors.registry.PLUGIN_NOT_IMPLEMENTED(
                 pluginsCompatibility.missing.join(', ')
               ),
               missingPlugins: pluginsCompatibility.missing
@@ -158,8 +156,7 @@ module.exports = function(conf, repository) {
             status: 400,
             response: {
               code: 'TEMPLATE_NOT_SUPPORTED',
-              error: format(
-                strings.errors.registry.TEMPLATE_NOT_SUPPORTED,
+              error: strings.errors.registry.TEMPLATE_NOT_SUPPORTED(
                 templateType
               )
             }
@@ -245,8 +242,7 @@ module.exports = function(conf, repository) {
               status: 500,
               response: {
                 code: 'GENERIC_ERROR',
-                error: format(
-                  strings.errors.registry.COMPONENT_EXECUTION_ERROR,
+                error: strings.errors.registry.COMPONENT_EXECUTION_ERROR(
                   err.message || ''
                 ),
                 details: {
@@ -294,9 +290,7 @@ module.exports = function(conf, repository) {
               })
             });
           } else {
-            const cacheKey = `${component.name}/${
-              component.version
-            }/template.js`;
+            const cacheKey = `${component.name}/${component.version}/template.js`;
             const cached = cache.get('file-contents', cacheKey);
             const key = component.oc.files.template.hashKey;
             const renderOptions = {
@@ -451,8 +445,7 @@ module.exports = function(conf, repository) {
                       status: 501,
                       response: {
                         code: err.code,
-                        error: format(
-                          strings.errors.registry.DEPENDENCY_NOT_FOUND,
+                        error: strings.errors.registry.DEPENDENCY_NOT_FOUND(
                           err.missing.join(', ')
                         ),
                         missingDependencies: err.missing

--- a/src/registry/routes/publish.js
+++ b/src/registry/routes/publish.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
-
 const extractPackage = require('../domain/extract-package');
 const strings = require('../../resources/index');
 const validator = require('../domain/validators');
@@ -22,8 +20,7 @@ module.exports = function(repository) {
       req.headers['user-agent']
     );
     if (!validationResult.isValid) {
-      res.errorDetails = format(
-        strings.errors.registry.OC_CLI_VERSION_IS_NOT_VALID,
+      res.errorDetails = strings.errors.registry.OC_CLI_VERSION_IS_NOT_VALID(
         validationResult.error.registryVersion,
         validationResult.error.cliVersion
       );
@@ -39,8 +36,7 @@ module.exports = function(repository) {
       process.version
     );
     if (!validationResult.isValid) {
-      res.errorDetails = format(
-        strings.errors.registry.NODE_CLI_VERSION_IS_NOT_VALID,
+      res.errorDetails = strings.errors.registry.NODE_CLI_VERSION_IS_NOT_VALID(
         validationResult.error.registryNodeVersion,
         validationResult.error.cliNodeVersion
       );

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -57,33 +57,36 @@ module.exports = {
   commands: {
     cli: {
       MOCK_PLUGIN: 'oc mock plugin <pluginName> "some value"',
-      UPGRADE: '[sudo] npm i -g oc@{0}'
+      UPGRADE: version => `[sudo] npm i -g oc@${version}`
     }
   },
   errors: {
     registry: {
-      BATCH_ROUTE_BODY_NOT_VALID: 'The request body is malformed: {0}',
+      BATCH_ROUTE_BODY_NOT_VALID: message =>
+        `The request body is malformed: ${message}`,
       BATCH_ROUTE_BODY_NOT_VALID_CODE: 'POST_BODY_NOT_VALID',
       BATCH_ROUTE_COMPONENTS_PROPERTY_MISSING: 'components property is missing',
       BATCH_ROUTE_COMPONENTS_NOT_ARRAY: 'components property is not an array',
-      BATCH_ROUTE_COMPONENT_NAME_MISSING:
-        'component {0} must have name property',
-      COMPONENT_EXECUTION_ERROR: 'Component execution error: {0}',
+      BATCH_ROUTE_COMPONENT_NAME_MISSING: idx =>
+        `component ${idx} must have name property`,
+      COMPONENT_EXECUTION_ERROR: msg => `Component execution error: ${msg}`,
       COMPONENT_NAME_NOT_VALID:
         "The component's name contains invalid characters. Allowed are alphanumeric, _, -",
       COMPONENT_NAME_NOT_VALID_CODE: 'name_not_valid',
-      COMPONENT_NOT_FOUND: 'Component "{0}" not found on {1}',
+      COMPONENT_NOT_FOUND: (name, source) =>
+        `Component "${name}" not found on ${source}`,
       COMPONENT_PUBLISHNAME_CONFLICT:
         'Component name conflict. Ensure package.json and components folder name are equal.',
-      COMPONENT_PUBLISHVALIDATION_FAIL: 'Component validation failed: {0}',
+      COMPONENT_PUBLISHVALIDATION_FAIL: error =>
+        `Component validation failed: ${error}`,
       COMPONENT_PUBLISHVALIDATION_FAIL_CODE: 'not_allowed',
-      COMPONENT_VERSION_NOT_FOUND:
-        'Component "{0}" with version "{1}" not found on {2}',
-      COMPONENT_VERSION_ALREADY_FOUND:
-        'Component "{0}" with version "{1}" can\'t be published to {2} because a component with the same name and version already exists',
+      COMPONENT_VERSION_NOT_FOUND: (name, version, source) =>
+        `Component "${name}" with version "${version}" not found on ${source}`,
+      COMPONENT_VERSION_ALREADY_FOUND: (name, version, source) =>
+        `Component "${name}" with version "${version}" can\'t be published to ${source} because a component with the same name and version already exists`,
       COMPONENT_VERSION_ALREADY_FOUND_CODE: 'already_exists',
-      COMPONENT_VERSION_NOT_VALID:
-        'Version "{0}" is not a valid semantic version.',
+      COMPONENT_VERSION_NOT_VALID: version =>
+        `Version "${version}" is not a valid semantic version.`,
       COMPONENT_VERSION_NOT_VALID_CODE: 'version_not_valid',
       COMPONENT_SET_HEADER_PARAMETERS_NOT_VALID:
         'context.setHeader parameters must be strings',
@@ -96,8 +99,8 @@ module.exports = {
         "Registry configuration is not valid: registry.off's callback must be a function",
       CONFIGURATION_PUBLISH_BASIC_AUTH_CREDENTIALS_MISSING:
         'Registry configuration is not valid: basic auth requires username and password',
-      CONFIGURATION_PUBLISH_AUTH_MODULE_NOT_FOUND:
-        'Registry configuration is not valid: module "{0}" not found',
+      CONFIGURATION_PUBLISH_AUTH_MODULE_NOT_FOUND: moduleName =>
+        `Registry configuration is not valid: module "${moduleName}" not found`,
       CONFIGURATION_PREFIX_DOES_NOT_END_WITH_SLASH:
         'Registry configuration is not valid: prefix should end with "/"',
       CONFIGURATION_PREFIX_DOES_NOT_START_WITH_SLASH:
@@ -108,41 +111,43 @@ module.exports = {
         'Registry configuration is not valid: each route should contain route, method and handler',
       CONFIGURATION_ROUTES_MUST_BE_ARRAY:
         'Registry configuration is not valid: routes must be an array',
-      CONFIGURATION_ROUTES_ROUTE_CONTAINS_PREFIX:
-        'Registry configuration is not valid: route url can\'t contain "{0}"',
-      CONFIGURATION_STORAGE_NOT_VALID:
-        'Registry configuration is not valid: {0} configuration is not valid',
+      CONFIGURATION_ROUTES_ROUTE_CONTAINS_PREFIX: prefix =>
+        `Registry configuration is not valid: route url can\'t contain "${prefix}"`,
+      CONFIGURATION_STORAGE_NOT_VALID: storage =>
+        `Registry configuration is not valid: ${storage} configuration is not valid`,
       CONFIGURATION_HEADERS_TO_SKIP_MUST_BE_STRING_ARRAY:
         'Registry configuration is not valid: customHeadersToSkipOnWeakVersion must be an array of strings',
       DATA_OBJECT_IS_UNDEFINED: 'data object is undefined',
-      DEPENDENCY_NOT_FOUND:
-        'Component is trying to use unavailable dependencies: {0}',
+      DEPENDENCY_NOT_FOUND: dependencies =>
+        `Component is trying to use unavailable dependencies: ${dependencies}`,
       DEPENDENCY_NOT_FOUND_CODE: 'DEPENDENCY_MISSING_FROM_REGISTRY',
       LOCAL_PUBLISH_NOT_ALLOWED:
         "Components can't be published to local repository",
       LOCAL_PUBLISH_NOT_ALLOWED_CODE: 'not_allowed',
       GENERIC_ERROR: 'error!',
-      MANDATORY_PARAMETER_MISSING:
-        'Expected mandatory parameters are missing: {0}',
+      MANDATORY_PARAMETER_MISSING: parameter =>
+        `Expected mandatory parameters are missing: ${parameter}`,
       MANDATORY_PARAMETER_MISSING_CODE: 'missing',
       NESTED_RENDERER_CALLBACK_IS_NOT_VALID: 'callback is not valid',
       NESTED_RENDERER_COMPONENT_NAME_IS_NOT_VALID:
         "component's name is not valid",
       NESTED_RENDERER_COMPONENTS_IS_NOT_VALID: 'components is not valid',
-      NODE_CLI_VERSION_IS_NOT_VALID:
-        'Node CLI version is not valid: Registry {0}, CLI {1}',
-      OC_CLI_VERSION_IS_NOT_VALID:
-        'OC CLI version is not valid: Registry {0}, CLI {1}',
-      PARAMETER_WRONG_FORMAT: 'Parameters are not correctly formatted: {0}',
+      NODE_CLI_VERSION_IS_NOT_VALID: (registry, cli) =>
+        `Node CLI version is not valid: Registry ${registry}, CLI ${cli}`,
+      OC_CLI_VERSION_IS_NOT_VALID: (registry, cli) =>
+        `OC CLI version is not valid: Registry ${registry}, CLI ${cli}`,
+      PARAMETER_WRONG_FORMAT: parameters =>
+        `Parameters are not correctly formatted: ${parameters}`,
       PARAMETER_WRONG_FORMAT_CODE: 'wrong type',
-      PLUGIN_NOT_FOUND: 'Component is trying to use un-registered plugins: {0}',
-      PLUGIN_NOT_IMPLEMENTED: 'registry does not implement plugins: {0}',
-      PLUGIN_NOT_VALID: 'Plugin {0} is not valid',
+      PLUGIN_NOT_IMPLEMENTED: plugins =>
+        `registry does not implement plugins: ${plugins}`,
+      PLUGIN_NOT_VALID: plugin => `Plugin ${plugin} is not valid`,
       RESOLVING_ERROR: 'component resolving error',
-      TEMPLATE_NOT_FOUND: 'Template {0} not found',
-      TEMPLATE_NOT_VALID: '{0} is not a valid oc-template',
-      TEMPLATE_NOT_SUPPORTED: '{0} is not a supported oc-template',
-      RENDER_ERROR: 'Render Error for {0}: {1}'
+      TEMPLATE_NOT_FOUND: template => `Template ${template} not found`,
+      TEMPLATE_NOT_SUPPORTED: templateType =>
+        `${templateType} is not a supported oc-template`,
+      RENDER_ERROR: (component, error) =>
+        `Render Error for ${component}: ${error}`
     },
     cli: {
       cleanRemoveError: err =>
@@ -154,51 +159,45 @@ module.exports = {
       COMPONENTS_NOT_FOUND: 'no components found in specified path',
       DEPENDENCIES_INSTALL_FAIL:
         'An error happened when installing the dependencies',
-      DEPENDENCY_LINK_FAIL:
-        'An error happened when linking the dependency {0} with error {1}',
+      DEPENDENCY_LINK_FAIL: (dependency, error) =>
+        `An error happened when linking the dependency ${dependency} with error ${error}`,
       DEPENDENCIES_LINK_FAIL: 'An error happened when linking the dependencies',
-      DEV_FAIL: 'An error happened when initialising the dev runner: {0}',
-      FOLDER_IS_NOT_A_FOLDER: '"{0}" must be a directory',
-      FOLDER_NOT_FOUND: '"{0}" not found',
-      INIT_FAIL: 'An error happened when initialising the component: {0}',
+      DEV_FAIL: error =>
+        `An error happened when initialising the dev runner: ${error}`,
+      INIT_FAIL: error =>
+        `An error happened when initialising the component: ${error}`,
       INVALID_CREDENTIALS: 'Invalid credentials',
       MOCK_PLUGIN_IS_NOT_VALID: mockPluginIsNotValid,
       NAME_NOT_VALID:
         'the name is not valid. Allowed characters are alphanumeric, _, -',
-      NODE_CLI_VERSION_NEEDS_UPGRADE:
-        "the version of used node is invalid. Try to upgrade node to version matching '{0}'",
-      NODE_CLI_VERSION_UNSUPPORTED:
-        "ALERT: You're currently running OC on an unsupported Node version ({0}).\nPlease upgrade Node to >= {1}.",
-      OC_CLI_VERSION_NEEDS_UPGRADE:
-        'the version of used OC CLI is invalid. Try to upgrade OC CLI running {0}',
-      PACKAGE_CREATION_FAIL: 'An error happened when creating the package: {0}',
-      PACKAGING_FAIL: 'an error happened while packaging {0}: {1}',
+      NODE_CLI_VERSION_NEEDS_UPGRADE: version =>
+        `the version of used node is invalid. Try to upgrade node to version matching '${version}'`,
+      NODE_CLI_VERSION_UNSUPPORTED: (nodeVersion, minVersion) =>
+        `ALERT: You're currently running OC on an unsupported Node version (${nodeVersion}).\nPlease upgrade Node to >= ${minVersion}.`,
+      OC_CLI_VERSION_NEEDS_UPGRADE: command =>
+        `the version of used OC CLI is invalid. Try to upgrade OC CLI running ${command}`,
+      PACKAGE_CREATION_FAIL: error =>
+        `An error happened when creating the package: ${error}`,
+      PACKAGING_FAIL: (dir, description) =>
+        `an error happened while packaging ${dir}: ${description}`,
       PACKAGE_FOLDER_MISSING:
         'Could not find a _package folder to publish. Try running "oc package" first, or do not skip packaging',
-      PLUGIN_MISSING_FROM_REGISTRY:
-        'Looks  like you are trying to use a plugin in the dev mode ({0}).\nYou need to mock it doing {1}',
-      PORT_IS_BUSY:
-        'The port {0} is already in use. Specify the optional port parameter to use another port.',
-      PUBLISHING_FAIL: 'An error happened when publishing the component: {0}',
+      PLUGIN_MISSING_FROM_REGISTRY: (details, command) =>
+        `Looks like you are trying to use a plugin in the dev mode (${details}).\nYou need to mock it doing ${command}`,
+      PORT_IS_BUSY: port =>
+        `The port ${port} is already in use. Specify the optional port parameter to use another port.`,
+      PUBLISHING_FAIL: error =>
+        `An error happened when publishing the component: ${error}`,
       REGISTRY_NOT_FOUND:
         'oc registries not found. Run "oc registry add <registry href>"',
-      SERVERJS_DEPENDENCY_NOT_DECLARED:
-        'Missing dependencies from package.json => {0}',
-      TEMPLATE_NOT_FOUND: 'Error requiring oc-template: "{0}" not found',
-      TEMPLATE_TYPE_NOT_VALID:
-        'Error requiring oc-template: "{0}" is not a valid oc-template',
-      TEMPLATE_DEP_MISSING:
-        'Template dependency missing. To fix it run:\n\nnpm install --save-dev {0}-compiler --prefix {1}\n\n'
+      TEMPLATE_NOT_FOUND: template =>
+        `Error requiring oc-template: "${template}" not found`,
+      TEMPLATE_TYPE_NOT_VALID: template =>
+        `Error requiring oc-template: "${template}" is not a valid oc-template`,
+      TEMPLATE_DEP_MISSING: (template, path) =>
+        `Template dependency missing. To fix it run:\n\nnpm install --save-dev ${template}-compiler --prefix ${path}\n\n`
     },
-    generic: 'An error occurred: {0}',
-    STORAGE: {
-      DIR_NOT_FOUND: 'Directory "{0}" not found',
-      DIR_NOT_FOUND_CODE: 'dir_not_found',
-      FILE_NOT_FOUND: 'File "{0}" not found',
-      FILE_NOT_FOUND_CODE: 'file_not_found',
-      FILE_NOT_VALID: 'File "{0}" not valid',
-      FILE_NOT_VALID_CODE: 'file_not_valid'
-    }
+    generic: error => `An error occurred: ${error}`
   },
   messages: {
     cli: {
@@ -214,39 +213,36 @@ module.exports = {
         `${green('✔')} Installed ${compiler} [${template} v${version}]`,
       legacyTemplateDeprecationWarning: (legacyType, newType) =>
         `Template-type "${legacyType}" has been deprecated and is now replaced by "${newType}"`,
-      CHANGES_DETECTED: 'Changes detected on file: {0}',
+      CHANGES_DETECTED: file => `Changes detected on file: ${file}`,
       CHECKING_DEPENDENCIES: 'Ensuring dependencies are loaded...',
-      COMPONENT_INITED: 'Success! Created "{0}"',
-      COMPRESSING: 'Compressing -> {0}',
-      COMPRESSED: 'Compressed -> {0}',
+      COMPRESSING: path => `Compressing -> ${path}`,
+      COMPRESSED: path => `Compressed -> ${path}`,
       ENTER_PASSWORD: 'Enter password:',
       ENTER_USERNAME: 'Enter username:',
       USING_CREDS: 'Using specified credentials',
       HELP_HINT: 'Hint: Run -h with any command to show the help',
       HOT_RELOADING_DISABLED:
         'OC dev is running with hot reloading disabled so changes will be ignored',
-      INSTALLING_DEPS:
-        "Trying to install missing modules: {0}\nIf you aren't connected to the internet, or npm isn't configured then this step will fail...",
-      LINKING_DEPENDENCIES:
-        'Trying to link missing modules: {0}\nThe missing dependencies will be linked to component dependencies',
-      MOCKED_PLUGIN: 'Mock for plugin has been registered: {0} () => {1}',
-      NO_SUCH_COMMAND: "No such command '{0}'",
-      NOT_VALID_REGISTRY_COMMAND:
-        'Not valid command: got {0}, allowed values: add, ls, remove',
-      PACKAGING: 'Packaging -> {0}',
-      PACKAGED: 'Packaged -> {0}',
+      INSTALLING_DEPS: dependencies =>
+        `Trying to install missing modules: ${dependencies}\nIf you aren't connected to the internet, or npm isn't configured then this step will fail...`,
+      LINKING_DEPENDENCIES: dependencies =>
+        `Trying to link missing modules: ${dependencies}\nThe missing dependencies will be linked to component dependencies`,
+      MOCKED_PLUGIN: (name, value) =>
+        `Mock for plugin has been registered: ${name} () => ${value}`,
+      NO_SUCH_COMMAND: command => `No such command '${command}'`,
+      PACKAGING: dir => `Packaging -> ${dir}`,
+      PACKAGED: dir => `Packaged -> ${dir}`,
       PACKAGING_COMPONENTS: 'Packaging components...',
-      PREVIEW_STARTED_AT_URL: "Component's preview started at url: {0}",
-      PUBLISHED: 'Published -> {0}',
-      PUBLISHING: 'Publishing -> {0}',
+      PUBLISHED: component => `Published -> ${component}`,
+      PUBLISHING: component => `Publishing -> ${component}`,
       REGISTERING_MOCKED_PLUGINS: 'Registering mocked plugins...',
       REGISTRY_ADDED: 'oc registry added',
       REGISTRY_CREDENTIALS_REQUIRED: 'Registry requires credentials.',
       REGISTRY_LIST: 'oc linked registries:',
       REGISTRY_REMOVED: 'oc registry deleted',
-      REGISTRY_STARTING: 'Starting dev registry on {0} ...',
-      REGISTRY_LIVERELOAD_STARTING:
-        'Starting live-reload server on port {0} ... (to disable use "--hotReloading=false")',
+      REGISTRY_STARTING: url => `Starting dev registry on ${url} ...`,
+      REGISTRY_LIVERELOAD_STARTING: port =>
+        `Starting live-reload server on port ${port} ... (to disable use "--hotReloading=false")`,
       RETRYING_10_SECONDS: 'Retrying in 10 seconds...',
       SCANNING_COMPONENTS: 'Looking for components...'
     }

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const async = require('async');
-const format = require('stringformat');
 const fs = require('fs');
 const path = require('path');
 const get = require('./git');
@@ -12,11 +11,7 @@ module.exports = () =>
       let result = '## Change Log';
       changelog.forEach(pr => {
         if (pr.changes.length > 0) {
-          result += format(
-            '\n\n### {0}\n{1}',
-            pr.tag.to,
-            pr.changes.join('\n')
-          );
+          result += `\n\n### ${pr.tag.to}\n${pr.changes.join('\n')}`;
         }
       });
       fs.writeFile(path.join(__dirname, '../CHANGELOG.md'), result, cb);

--- a/tasks/git.js
+++ b/tasks/git.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const simpleGit = require('simple-git');
 const git = simpleGit(path.join(__dirname, '..'));
-const format = require('stringformat');
 const fs = require('fs');
 
 const utils = {
@@ -25,11 +24,7 @@ const utils = {
         commitMessage = commit.body;
 
         result.push(
-          format(
-            '- [#{0}](https://github.com/opencomponents/oc/pull/{0}) {1}',
-            prNumber,
-            commitMessage
-          )
+          `- [#${prNumber}](https://github.com/opencomponents/oc/pull/${prNumber}) ${commitMessage}`
         );
       } else if (isSquashedPr) {
         const lines = commit.message.split('\n');
@@ -44,11 +39,7 @@ const utils = {
         commitMessage = commitLine.substr(0, prNumberStartIndex).trim();
 
         result.push(
-          format(
-            '- [#{0}](https://github.com/opencomponents/oc/pull/{0}) {1}',
-            prNumber,
-            commitMessage
-          )
+          `- [#${prNumber}](https://github.com/opencomponents/oc/pull/${prNumber}) ${commitMessage}`
         );
       }
     });

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -6,7 +6,6 @@ const injectr = require('injectr');
 const path = require('path');
 const sinon = require('sinon');
 const _ = require('lodash');
-const resources = require('../../src/resources');
 
 describe('registry : domain : repository', () => {
   let response;
@@ -192,8 +191,8 @@ describe('registry : domain : repository', () => {
             .stub(repository, 'getComponentInfo')
             .callsFake((name, version, callback) => {
               callback({
-                msg: resources.errors.STORAGE.FILE_NOT_VALID,
-                code: resources.errors.STORAGE.FILE_NOT_VALID_CODE
+                msg: 'File not valid',
+                code: 'file_not_valid'
               });
             });
           repository.getComponent('hello-world', '1.0.0', saveResult(done));
@@ -204,7 +203,7 @@ describe('registry : domain : repository', () => {
         it('should respond with a proper error', () => {
           expect(response.error).not.to.be.empty;
           expect(response.error).to.equal(
-            `component not available: ${resources.errors.STORAGE.FILE_NOT_VALID}`
+            `component not available: File not valid`
           );
         });
       });


### PR DESCRIPTION
`stringformat` is a [deprecated package](https://www.npmjs.com/package/stringformat), and as they state it.

```
This package has been rendered useless by string literals, and may present unknown vulnerabilities. Please stop depending on it.
```

So this PR removes all stringformat messages in favour of string literals.