### PR TITLE
[BREAKING] Update oc-client-browser to 1.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "multer": "^1.3.0",
     "nice-cache": "0.0.5",
     "oc-client": "3.2.12",
-    "oc-client-browser": "1.4.2",
+    "oc-client-browser": "1.5.3",
     "oc-empty-response-handler": "1.0.0",
     "oc-get-unix-utc-timestamp": "1.0.2",
     "oc-s3-storage-adapter": "1.1.6",


### PR DESCRIPTION
This upgrade creates a small breaking change, since it updates jQuery from 1.11.2 to 3.6.0, and because `oc.$` exposes that jQuery, components that relied on the very old [deprecated methods](https://jquery.com/upgrade-guide/3.0/) from jQuery 1 won't work anymore.