### PR TITLE
remove new references on non-classes

### DIFF
--- a/src/cli/domain/local.js
+++ b/src/cli/domain/local.js
@@ -14,7 +14,7 @@ const strings = require('../../resources');
 const validator = require('../../registry/domain/validators');
 
 module.exports = function() {
-  return _.extend(this, {
+  return {
     clean,
     cleanup: function(compressedPackagePath, callback) {
       return fs.unlink(compressedPackagePath, callback);
@@ -71,5 +71,5 @@ module.exports = function() {
     },
     mock: mock(),
     package: packageComponents()
-  });
+  };
 };

--- a/src/cli/domain/registry.js
+++ b/src/cli/domain/registry.js
@@ -26,7 +26,7 @@ module.exports = function(opts) {
     }-${process.arch}`
   };
 
-  return _.extend(this, {
+  return {
     add: function(registry, callback) {
       if (registry.slice(registry.length - 1) !== '/') {
         registry += '/';
@@ -159,5 +159,5 @@ module.exports = function(opts) {
         fs.writeJson(settings.configFile.src, res, callback);
       });
     }
-  });
+  };
 };

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -157,7 +157,7 @@ module.exports = function(dependencies) {
                 return callback(err);
               }
 
-              const registry = new oc.Registry({
+              const registry = oc.Registry({
                 baseUrl,
                 prefix: opts.prefix || '',
                 dependencies: dependencies.modules,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -23,9 +23,9 @@ if (semver.lt(currentNodeVersion, minSupportedVersion)) {
 }
 
 const dependencies = {
-  local: new Local(),
+  local: Local(),
   logger,
-  registry: new Registry()
+  registry: Registry()
 };
 
 function processCommand(command, commandName, cli, level, prefix) {

--- a/src/cli/programmatic-api.js
+++ b/src/cli/programmatic-api.js
@@ -6,13 +6,13 @@ const Local = require('./domain/local');
 function wrap(cmdScript, withRegistry) {
   return function(options, cb) {
     const dependencies = {
-      local: new Local(),
+      local: Local(),
       logger: options.logger || { log() {}, err() {}, ok() {}, warn() {} }
     };
 
     if (withRegistry) {
       const Registry = require('./domain/registry');
-      dependencies.registry = new Registry({ registry: options.registry });
+      dependencies.registry = Registry({ registry: options.registry });
     }
 
     const opts = _.omit(options, 'logger', 'registry');

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -16,7 +16,7 @@ const versionHandler = require('./version-handler');
 const errorToString = require('../../utils/error-to-string');
 
 module.exports = function(conf) {
-  const cdn = !conf.local && new conf.storage.adapter(conf.storage.options);
+  const cdn = !conf.local && conf.storage.adapter(conf.storage.options);
   const options = !conf.local && conf.storage.options;
   const repositorySource = conf.local
     ? 'local repository'

--- a/src/registry/index.js
+++ b/src/registry/index.js
@@ -25,7 +25,7 @@ module.exports = function(options) {
   const plugins = [];
   const app = middleware.bind(express(), options);
   let server;
-  const repository = new Repository(options);
+  const repository = Repository(options);
 
   const close = callback => {
     if (server && server.listening) {

--- a/src/registry/router.js
+++ b/src/registry/router.js
@@ -15,15 +15,15 @@ const settings = require('../resources/settings');
 
 module.exports.create = function(app, conf, repository) {
   const routes = {
-    component: new ComponentRoute(conf, repository),
-    components: new ComponentsRoute(conf, repository),
-    componentInfo: new ComponentInfoRoute(conf, repository),
-    componentPreview: new ComponentPreviewRoute(conf, repository),
-    index: new IndexRoute(repository),
-    publish: new PublishRoute(repository),
-    staticRedirector: new StaticRedirectorRoute(repository),
-    plugins: new PluginsRoute(conf),
-    dependencies: new DependenciesRoute(conf)
+    component: ComponentRoute(conf, repository),
+    components: ComponentsRoute(conf, repository),
+    componentInfo: ComponentInfoRoute(conf, repository),
+    componentPreview: ComponentPreviewRoute(conf, repository),
+    index: IndexRoute(repository),
+    publish: PublishRoute(repository),
+    staticRedirector: StaticRedirectorRoute(repository),
+    plugins: PluginsRoute(conf),
+    dependencies: DependenciesRoute(conf)
   };
 
   const prefix = conf.prefix;

--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -7,7 +7,7 @@ const GetComponentHelper = require('./helpers/get-component');
 const strings = require('../../resources');
 
 module.exports = function(conf, repository) {
-  const getComponent = new GetComponentHelper(conf, repository);
+  const getComponent = GetComponentHelper(conf, repository);
 
   return function(req, res) {
     getComponent(

--- a/src/registry/routes/components.js
+++ b/src/registry/routes/components.js
@@ -7,7 +7,7 @@ const GetComponentHelper = require('./helpers/get-component');
 const strings = require('../../resources');
 
 module.exports = function(conf, repository) {
-  const getComponent = new GetComponentHelper(conf, repository);
+  const getComponent = GetComponentHelper(conf, repository);
   const setHeaders = (results, res) => {
     if (!results || results.length !== 1 || !results[0] || !res.set) {
       return;

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -22,15 +22,15 @@ const urlBuilder = require('../../domain/url-builder');
 const validator = require('../../domain/validators');
 
 module.exports = function(conf, repository) {
-  const client = new Client({ templates: conf.templates }),
+  const client = Client({ templates: conf.templates }),
     cache = new Cache({
       verbose: !!conf.verbosity,
       refreshInterval: conf.refreshInterval
     });
 
   const renderer = function(options, cb) {
-    const nestedRenderer = new NestedRenderer(renderer, options.conf),
-      retrievingInfo = new GetComponentRetrievingInfo(options);
+    const nestedRenderer = NestedRenderer(renderer, options.conf),
+      retrievingInfo = GetComponentRetrievingInfo(options);
     let responseHeaders = {};
 
     const getLanguage = () => {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -41,7 +41,7 @@ ocClientBrowser.getLib((err, libContent) => {
     );
 
     const Local = require('../src/cli/domain/local');
-    const local = new Local();
+    const local = Local();
     const packageOptions = {
       componentPath: path.join(__dirname, clientComponentDir),
       production: true,

--- a/test/acceptance/registry-ui.js
+++ b/test/acceptance/registry-ui.js
@@ -27,7 +27,7 @@ describe('registry (ui interface)', () => {
   };
 
   const initializeRegistry = (configuration, cb) => {
-    registry = new oc.Registry(configuration);
+    registry = oc.Registry(configuration);
     registry.start(cb);
   };
 

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -34,7 +34,7 @@ describe('registry', () => {
   };
 
   const initializeRegistry = function(configuration, cb) {
-    registry = new oc.Registry(configuration);
+    registry = oc.Registry(configuration);
     registry.start(cb);
   };
 

--- a/test/acceptance/registry/registry-with-fallback.js
+++ b/test/acceptance/registry/registry-with-fallback.js
@@ -36,14 +36,14 @@ describe('registry', () => {
     }
 
     before(done => {
-      registry = new oc.Registry(
+      registry = oc.Registry(
         retrieveRegistryConfiguration(
           3030,
           'test/fixtures/components',
           'http://localhost:3031'
         )
       );
-      fallbackRegistry = new oc.Registry(
+      fallbackRegistry = oc.Registry(
         retrieveRegistryConfiguration(
           3031,
           'test/fixtures/fallback-registry-components'

--- a/test/unit/cli-domain-get-components-by-dir.js
+++ b/test/unit/cli-domain-get-components-by-dir.js
@@ -29,7 +29,7 @@ const initialise = function() {
     { __dirname: '' }
   );
 
-  const local = new GetComponentsByDir();
+  const local = GetComponentsByDir();
 
   return { local: local, fs: fsMock };
 };

--- a/test/unit/cli-domain-mock.js
+++ b/test/unit/cli-domain-mock.js
@@ -36,7 +36,7 @@ const initialise = function() {
     { __dirname: '' }
   );
 
-  const local = new Local();
+  const local = Local();
 
   return { local: local, fs: fsMock };
 };

--- a/test/unit/cli-domain-registry.js
+++ b/test/unit/cli-domain-registry.js
@@ -29,7 +29,7 @@ const getRegistry = function(dependencies, opts) {
     }
   );
 
-  return new Registry(opts);
+  return Registry(opts);
 };
 
 describe('cli : domain : registry', () => {

--- a/test/unit/cli-facade-clean.js
+++ b/test/unit/cli-facade-clean.js
@@ -26,7 +26,7 @@ describe('cli : facade : clean', () => {
       read: readMock
     });
 
-    const cleanFacade = new CleanFacade({ local, logger: logSpy });
+    const cleanFacade = CleanFacade({ local, logger: logSpy });
     cleanFacade(options.params, () => {
       done();
     });

--- a/test/unit/cli-facade-dev.js
+++ b/test/unit/cli-facade-dev.js
@@ -7,8 +7,8 @@ describe('cli : facade : dev', () => {
   const logSpy = {},
     DevFacade = require('../../src/cli/facade/dev'),
     Local = require('../../src/cli/domain/local'),
-    local = new Local(),
-    devFacade = new DevFacade({ local, logger: logSpy });
+    local = Local(),
+    devFacade = DevFacade({ local, logger: logSpy });
 
   const execute = function(dirName, port) {
     logSpy.err = sinon.spy();

--- a/test/unit/cli-facade-init.js
+++ b/test/unit/cli-facade-init.js
@@ -15,8 +15,8 @@ describe('cli : facade : init', () => {
   const logSpy = {},
     InitFacade = require('../../src/cli/facade/init'),
     Local = injectr('../../src/cli/domain/local.js', deps, {}),
-    local = new Local({ logger: { log: () => {} } }),
-    initFacade = new InitFacade({ local: local, logger: logSpy });
+    local = Local({ logger: { log: () => {} } }),
+    initFacade = InitFacade({ local: local, logger: logSpy });
 
   const execute = function(componentPath, templateType) {
     logSpy.err = sinon.spy();

--- a/test/unit/cli-facade-mock.js
+++ b/test/unit/cli-facade-mock.js
@@ -7,8 +7,8 @@ describe('cli : facade : mock', () => {
   const logSpy = {},
     MockFacade = require('../../src/cli/facade/mock'),
     Local = require('../../src/cli/domain/local'),
-    local = new Local(),
-    mockFacade = new MockFacade({ local: local, logger: logSpy });
+    local = Local(),
+    mockFacade = MockFacade({ local: local, logger: logSpy });
 
   const execute = function() {
     logSpy.ok = sinon.spy();

--- a/test/unit/cli-facade-package.js
+++ b/test/unit/cli-facade-package.js
@@ -7,9 +7,9 @@ const sinon = require('sinon');
 describe('cli : facade : package', () => {
   const logSpy = {},
     Local = require('../../src/cli/domain/local'),
-    local = new Local(),
+    local = Local(),
     PackageFacade = require('../../src/cli/facade/package.js'),
-    packageFacade = new PackageFacade({ local: local, logger: logSpy });
+    packageFacade = PackageFacade({ local: local, logger: logSpy });
 
   const execute = function(compress, cb) {
     logSpy.err = sinon.stub();

--- a/test/unit/cli-facade-preview.js
+++ b/test/unit/cli-facade-preview.js
@@ -17,7 +17,7 @@ describe('cli : facade : preview', () => {
     const PreviewFacade = injectr('../../src/cli/facade/preview.js', {
         open: openSpy
       }),
-      previewFacade = new PreviewFacade({
+      previewFacade = PreviewFacade({
         logger: logSpy,
         registry: registryStub
       });

--- a/test/unit/cli-facade-publish.js
+++ b/test/unit/cli-facade-publish.js
@@ -9,9 +9,9 @@ const sinon = require('sinon');
 describe('cli : facade : publish', () => {
   const logSpy = {},
     Registry = require('../../src/cli/domain/registry'),
-    registry = new Registry(),
+    registry = Registry(),
     Local = require('../../src/cli/domain/local'),
-    local = new Local(),
+    local = Local(),
     readStub = sinon.stub().yields(null, 'test'),
     mockComponent = {
       name: 'hello-world',
@@ -37,7 +37,7 @@ describe('cli : facade : publish', () => {
         'fs-extra': fsMock,
         read: readStub
       }),
-      publishFacade = new PublishFacade({
+      publishFacade = PublishFacade({
         registry,
         local,
         logger: logSpy

--- a/test/unit/cli-facade-registry-add.js
+++ b/test/unit/cli-facade-registry-add.js
@@ -6,9 +6,9 @@ const sinon = require('sinon');
 describe('cli : facade : registry : add', () => {
   const logSpy = {},
     Registry = require('../../src/cli/domain/registry'),
-    registry = new Registry(),
+    registry = Registry(),
     RegistryFacade = require('../../src/cli/facade/registry-add'),
-    registryFacade = new RegistryFacade({ registry: registry, logger: logSpy });
+    registryFacade = RegistryFacade({ registry: registry, logger: logSpy });
 
   const execute = function() {
     logSpy.err = sinon.spy();

--- a/test/unit/cli-facade-registry-ls.js
+++ b/test/unit/cli-facade-registry-ls.js
@@ -6,9 +6,9 @@ const sinon = require('sinon');
 describe('cli : facade : registry : ls', () => {
   const logSpy = {},
     Registry = require('../../src/cli/domain/registry'),
-    registry = new Registry(),
+    registry = Registry(),
     RegistryFacade = require('../../src/cli/facade/registry-ls'),
-    registryFacade = new RegistryFacade({ registry: registry, logger: logSpy });
+    registryFacade = RegistryFacade({ registry: registry, logger: logSpy });
 
   const execute = function() {
     logSpy.err = sinon.spy();

--- a/test/unit/cli-facade-registry-remove.js
+++ b/test/unit/cli-facade-registry-remove.js
@@ -6,9 +6,9 @@ const sinon = require('sinon');
 describe('cli : facade : registry : remove', () => {
   const logSpy = {},
     Registry = require('../../src/cli/domain/registry'),
-    registry = new Registry(),
+    registry = Registry(),
     RegistryFacade = require('../../src/cli/facade/registry-remove'),
-    registryFacade = new RegistryFacade({ registry: registry, logger: logSpy });
+    registryFacade = RegistryFacade({ registry: registry, logger: logSpy });
 
   const execute = function() {
     logSpy.err = sinon.spy();

--- a/test/unit/registry-domain-nested-renderer.js
+++ b/test/unit/registry-domain-nested-renderer.js
@@ -20,7 +20,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
       renderer = sinon.stub().yields(rendererMocks);
     }
 
-    nestedRenderer = new NestedRenderer(renderer, conf || {});
+    nestedRenderer = NestedRenderer(renderer, conf || {});
   };
 
   describe('when rendering nested component', () => {

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -86,7 +86,7 @@ describe('registry : domain : repository', () => {
       components: { 'hello-world': { '1.0.0': { publishDate: 1234567890 } } }
     };
 
-    const repository = new Repository(cdnConfiguration);
+    const repository = Repository(cdnConfiguration);
 
     describe('when getting the list of available components', () => {
       before(done => {
@@ -149,7 +149,7 @@ describe('registry : domain : repository', () => {
           const conf = _.extend(cdnConfiguration, {
             templates: [require('oc-template-jade')]
           });
-          const repository = new Repository(conf);
+          const repository = Repository(conf);
           expect(repository.getTemplatesInfo().length).to.equal(3);
         });
       });
@@ -400,7 +400,7 @@ describe('registry : domain : repository', () => {
       env: { name: 'local' }
     };
 
-    const repository = new Repository(localConfiguration);
+    const repository = Repository(localConfiguration);
 
     describe('when getting the list of available components', () => {
       before(done => {

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -44,7 +44,7 @@ describe('registry : routes : component', () => {
     let code, response;
     before(done => {
       initialise(mockedComponents['timeout-component']);
-      componentRoute = new ComponentRoute({}, mockedRepository);
+      componentRoute = ComponentRoute({}, mockedRepository);
 
       const resStatus = function(calledCode) {
         code = calledCode;
@@ -93,7 +93,7 @@ describe('registry : routes : component', () => {
   describe('when getting a component with a server.js that returns undefined data', () => {
     before(() => {
       initialise(mockedComponents['undefined-component']);
-      componentRoute = new ComponentRoute({}, mockedRepository);
+      componentRoute = ComponentRoute({}, mockedRepository);
 
       componentRoute(
         {
@@ -128,7 +128,7 @@ describe('registry : routes : component', () => {
   describe('when getting a component with server.js execution errors', () => {
     before(() => {
       initialise(mockedComponents['error-component']);
-      componentRoute = new ComponentRoute({}, mockedRepository);
+      componentRoute = ComponentRoute({}, mockedRepository);
 
       componentRoute(
         {
@@ -169,7 +169,7 @@ describe('registry : routes : component', () => {
     describe('when has error that gets fired on first execution', () => {
       before(done => {
         initialise(mockedComponents['async-error-component']);
-        componentRoute = new ComponentRoute({}, mockedRepository);
+        componentRoute = ComponentRoute({}, mockedRepository);
         statusStub.returns({
           json: function(response) {
             resJsonStub(response);
@@ -211,7 +211,7 @@ describe('registry : routes : component', () => {
     describe('when has error that gets fired on following executions', () => {
       before(done => {
         initialise(mockedComponents['async-error2-component']);
-        componentRoute = new ComponentRoute({}, mockedRepository);
+        componentRoute = ComponentRoute({}, mockedRepository);
         statusStub.returns({
           json: function(response) {
             resJsonStub(response);
@@ -282,7 +282,7 @@ describe('registry : routes : component', () => {
     describe('when plugin not declared in package.json', () => {
       before(() => {
         initialise(mockedComponents['plugin-component']);
-        componentRoute = new ComponentRoute({}, mockedRepository);
+        componentRoute = ComponentRoute({}, mockedRepository);
 
         componentRoute(
           {
@@ -324,7 +324,7 @@ describe('registry : routes : component', () => {
         const component = _.clone(mockedComponents['plugin-component']);
         component.package.oc.plugins = ['doSomething'];
         initialise(component);
-        componentRoute = new ComponentRoute({}, mockedRepository);
+        componentRoute = ComponentRoute({}, mockedRepository);
       });
 
       describe('when registry implements plugin', () => {
@@ -406,7 +406,7 @@ describe('registry : routes : component', () => {
     describe('when registry implements dependency', () => {
       beforeEach(() => {
         initialise(mockedComponents['npm-component']);
-        componentRoute = new ComponentRoute({}, mockedRepository);
+        componentRoute = ComponentRoute({}, mockedRepository);
 
         componentRoute(
           {
@@ -442,7 +442,7 @@ describe('registry : routes : component', () => {
     describe('when registry does not implement dependency', () => {
       beforeEach(() => {
         initialise(mockedComponents['npm-component']);
-        componentRoute = new ComponentRoute({}, mockedRepository);
+        componentRoute = ComponentRoute({}, mockedRepository);
 
         componentRoute(
           {
@@ -488,7 +488,7 @@ describe('registry : routes : component', () => {
   describe('when getting a component with server.js that sets custom headers with empty customHeadersToSkipOnWeakVersion', () => {
     before(() => {
       initialise(mockedComponents['response-headers-component']);
-      componentRoute = new ComponentRoute({}, mockedRepository);
+      componentRoute = ComponentRoute({}, mockedRepository);
 
       componentRoute(
         {
@@ -530,7 +530,7 @@ describe('registry : routes : component', () => {
   describe('when getting a component with server.js that sets custom headers with non-empty customHeadersToSkipOnWeakVersion', () => {
     before(done => {
       initialise(mockedComponents['response-headers-component']);
-      componentRoute = new ComponentRoute({}, mockedRepository);
+      componentRoute = ComponentRoute({}, mockedRepository);
 
       statusStub.returns({
         json: function(response) {
@@ -632,7 +632,7 @@ describe('registry : routes : component', () => {
         filePath: '/path/to/another-server.js'
       });
 
-      componentRoute = new ComponentRoute({}, mockedRepository);
+      componentRoute = ComponentRoute({}, mockedRepository);
 
       resJsonStub = sinon.stub();
       resSetStub = sinon.stub();
@@ -720,7 +720,7 @@ describe('registry : routes : component', () => {
   describe('when getting a component info for a component that sets custom headers', () => {
     before(() => {
       initialise(mockedComponents['response-headers-component']);
-      componentRoute = new ComponentRoute({}, mockedRepository);
+      componentRoute = ComponentRoute({}, mockedRepository);
 
       componentRoute(
         {

--- a/test/unit/registry-routes-components.js
+++ b/test/unit/registry-routes-components.js
@@ -74,7 +74,7 @@ describe('registry : routes : components', () => {
   describe('when making valid request for two components', () => {
     before(done => {
       initialise(mockedComponents['async-error2-component']);
-      componentsRoute = new ComponentsRoute({}, mockedRepository);
+      componentsRoute = ComponentsRoute({}, mockedRepository);
 
       makeRequest(
         {
@@ -153,7 +153,7 @@ describe('registry : routes : components', () => {
   describe('when making valid info request for two components', () => {
     before(done => {
       initialise(mockedComponents['async-error2-component']);
-      componentsRoute = new ComponentsRoute({}, mockedRepository);
+      componentsRoute = ComponentsRoute({}, mockedRepository);
 
       makeInfoRequest(
         {

--- a/test/unit/registry-routes-dependencies.js
+++ b/test/unit/registry-routes-dependencies.js
@@ -40,7 +40,7 @@ describe('registry : routes : plugins', () => {
         dependencies: ['fs', 'got'],
         discovery: false
       };
-      dependenciesRoute = new DependenciesRoute(conf);
+      dependenciesRoute = DependenciesRoute(conf);
 
       dependenciesRoute({ headers: {} }, { conf, status: statusStub });
     });
@@ -57,7 +57,7 @@ describe('registry : routes : plugins', () => {
         dependencies: ['fs', 'got'],
         discovery: true
       };
-      dependenciesRoute = new DependenciesRoute(conf);
+      dependenciesRoute = DependenciesRoute(conf);
 
       dependenciesRoute({ headers: {} }, { conf, status: statusStub });
     });

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -23,7 +23,7 @@ describe('registry : routes : helpers : get-component', () => {
           fire: fireStub
         },
         'oc-client': function() {
-          const client = new Client();
+          const client = Client();
           return {
             renderTemplate: (template, data, renderOptions, cb) => {
               if (renderOptions.templateType === 'oc-template-supported') {

--- a/test/unit/registry-routes-plugins.js
+++ b/test/unit/registry-routes-plugins.js
@@ -27,7 +27,7 @@ describe('registry : routes : plugins', () => {
         plugins,
         discovery: false
       };
-      pluginsRoute = new PluginsRoute(conf);
+      pluginsRoute = PluginsRoute(conf);
 
       pluginsRoute({ headers: {} }, { conf, status: statusStub });
     });
@@ -44,7 +44,7 @@ describe('registry : routes : plugins', () => {
         plugins,
         discovery: true
       };
-      pluginsRoute = new PluginsRoute(conf);
+      pluginsRoute = PluginsRoute(conf);
 
       pluginsRoute({ headers: {} }, { conf, status: statusStub });
     });

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -54,7 +54,7 @@ describe('registry', () => {
         });
         deps.express.returns('express instance');
         deps['./domain/options-sanitiser'].returns({ port: 3000 });
-        registry = new Registry({});
+        registry = Registry({});
       });
 
       it('should instantiate express', () => {


### PR DESCRIPTION
Removing `new` references on functions that return normal objects (not classes), since it's not needed.