### PR TITLE
add request ip to the context obj

### DIFF
--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -14,6 +14,7 @@ module.exports = function(conf, repository) {
       {
         conf: res.conf,
         headers: req.headers,
+        ip: req.ip,
         name: req.params.componentName,
         parameters: req.query,
         version: req.params.componentVersion

--- a/src/registry/routes/components.js
+++ b/src/registry/routes/components.js
@@ -56,6 +56,7 @@ module.exports = function(conf, repository) {
             conf: res.conf,
             name: component.name,
             headers: req.headers,
+            ip: req.ip,
             omitHref: !!req.body.omitHref,
             parameters: _.extend({}, req.body.parameters, component.parameters),
             version: component.version

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -373,6 +373,7 @@ module.exports = function(conf, repository) {
             renderComponent: nestedRenderer.renderComponent,
             renderComponents: nestedRenderer.renderComponents,
             requestHeaders: options.headers,
+            requestIp: options.ip,
             setEmptyResponse,
             staticPath: repository
               .getStaticFilePath(component.name, component.version, '')


### PR DESCRIPTION
Closes #1211

Adds Express `request.ip` to the context object, for components that need that information.