### PR TITLE
replace _.keys and _.values with their Object methods

### DIFF
--- a/src/cli/domain/handle-dependencies/index.js
+++ b/src/cli/domain/handle-dependencies/index.js
@@ -71,8 +71,8 @@ module.exports = (options, callback) => {
     }
 
     const result = {
-      modules: _.union(coreModules, _.keys(dependencies)).sort(),
-      templates: _.values(templates)
+      modules: _.union(coreModules, Object.keys(dependencies)).sort(),
+      templates: Object.values(templates)
     };
     const options = { dependencies, logger };
     if (useComponentDependencies) {

--- a/src/cli/validate-command.js
+++ b/src/cli/validate-command.js
@@ -5,9 +5,9 @@ const commands = require('./commands');
 const strings = require('../resources');
 
 const validateCommand = (argv, level) => {
-  let keys = _.keys(commands.commands);
+  let keys = Object.keys(commands.commands);
   if (level === 1) {
-    keys = _.keys(commands.commands[argv._[0]].commands);
+    keys = Object.keys(commands.commands[argv._[0]].commands);
   }
 
   if (argv._.length > level && !_.includes(keys, argv._[level])) {

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -204,7 +204,7 @@ module.exports = function(conf) {
       }
 
       componentsCache.get((err, res) =>
-        callback(err, res ? _.keys(res.components) : null)
+        callback(err, res ? Object.keys(res.components) : null)
       );
     },
     getComponentsDetails: callback => {

--- a/src/registry/domain/url-builder.js
+++ b/src/registry/domain/url-builder.js
@@ -52,14 +52,14 @@ const build = {
   queryString: function(parameters) {
     let qs = '';
 
-    if (_.keys(parameters).length > 0) {
+    if (Object.keys(parameters).length > 0) {
       qs += '?';
 
       _.forEach(parameters, (parameter, key) => {
         qs += key + '=' + encodeURIComponent(parameter) + '&';
       });
 
-      if (_.keys(parameters).length > 0) {
+      if (Object.keys(parameters).length > 0) {
         qs = qs.slice(0, -1);
       }
     }

--- a/src/registry/domain/validators/component-parameters.js
+++ b/src/registry/domain/validators/component-parameters.js
@@ -71,7 +71,7 @@ module.exports = function(requestParameters, expectedParameters) {
   result.errors.message = (function() {
     let errorString = '';
 
-    if (_.keys(result.errors.mandatory).length > 0) {
+    if (Object.keys(result.errors.mandatory).length > 0) {
       const missingParams = _.map(
         result.errors.mandatory,
         (mandatoryParameter, mandatoryParameterName) =>
@@ -85,7 +85,7 @@ module.exports = function(requestParameters, expectedParameters) {
       );
     }
 
-    if (_.keys(result.errors.types).length > 0) {
+    if (Object.keys(result.errors.types).length > 0) {
       if (errorString.length > 0) {
         errorString += '; ';
       }

--- a/src/registry/domain/validators/plugins-requirements.js
+++ b/src/registry/domain/validators/plugins-requirements.js
@@ -10,7 +10,7 @@ module.exports = function(componentRequirements, registryPlugins) {
     if (
       !registryPlugins ||
       _.isEmpty(registryPlugins) ||
-      !_.includes(_.keys(registryPlugins), requiredPlugin)
+      !_.includes(Object.keys(registryPlugins), requiredPlugin)
     ) {
       missing.push(requiredPlugin);
     }

--- a/src/registry/domain/validators/registry-configuration.js
+++ b/src/registry/domain/validators/registry-configuration.js
@@ -14,7 +14,7 @@ module.exports = function(conf) {
     return response;
   };
 
-  if (!conf || !_.isObject(conf) || _.keys(conf).length === 0) {
+  if (!conf || !_.isObject(conf) || Object.keys(conf).length === 0) {
     return returnError(strings.errors.registry.CONFIGURATION_EMPTY);
   }
 

--- a/src/registry/domain/validators/uploaded-package.js
+++ b/src/registry/domain/validators/uploaded-package.js
@@ -11,11 +11,11 @@ module.exports = function(input) {
     return response;
   };
 
-  if (!input || !_.isObject(input) || _.keys(input).length === 0) {
+  if (!input || !_.isObject(input) || Object.keys(input).length === 0) {
     return returnError('empty');
   }
 
-  if (_.keys(input).length !== 1) {
+  if (Object.keys(input).length !== 1) {
     return returnError('not_valid');
   }
 

--- a/src/registry/index.js
+++ b/src/registry/index.js
@@ -78,7 +78,8 @@ module.exports = function(options) {
             ok(`Registry started at port ${app.get('port')}`);
 
             if (_.isObject(componentsInfo)) {
-              const componentsNumber = _.keys(componentsInfo.components).length;
+              const componentsNumber = Object.keys(componentsInfo.components)
+                .length;
               const componentsReleases = _.reduce(
                 componentsInfo.components,
                 (memo, component) => parseInt(memo, 10) + component.length

--- a/src/registry/routes/component-info.js
+++ b/src/registry/routes/component-info.js
@@ -12,7 +12,7 @@ function getParams(component) {
   let params = {};
   if (component.oc.parameters) {
     const mandatoryParams = _.filter(
-      _.keys(component.oc.parameters),
+      Object.keys(component.oc.parameters),
       paramName => {
         const param = component.oc.parameters[paramName];
         return !!param.mandatory && !!param.example;
@@ -61,7 +61,7 @@ function componentInfo(err, req, res, component) {
       res.send(
         infoView({
           component,
-          dependencies: _.keys(component.dependencies),
+          dependencies: Object.keys(component.dependencies),
           href,
           parsedAuthor,
           repositoryUrl,

--- a/src/registry/routes/component-preview.js
+++ b/src/registry/routes/component-preview.js
@@ -15,9 +15,7 @@ function componentPreview(err, req, res, component, templates) {
 
   let liveReload = '';
   if (res.conf.liveReloadPort) {
-    liveReload = `<script src="http://localhost:${
-      res.conf.liveReloadPort
-    }/livereload.js?snipver=1"></script>`;
+    liveReload = `<script src="http://localhost:${res.conf.liveReloadPort}/livereload.js?snipver=1"></script>`;
   }
 
   const isHtmlRequest =
@@ -27,7 +25,7 @@ function componentPreview(err, req, res, component, templates) {
     return res.send(
       previewView({
         component,
-        dependencies: _.keys(component.dependencies),
+        dependencies: Object.keys(component.dependencies),
         href: res.conf.baseUrl,
         liveReload,
         qs: urlBuilder.queryString(req.query),

--- a/test/unit/cli-domain-handle-dependencies-get-missing-dependencies.js
+++ b/test/unit/cli-domain-handle-dependencies-get-missing-dependencies.js
@@ -3,7 +3,6 @@
 const expect = require('chai').expect;
 const injectr = require('injectr');
 const sinon = require('sinon');
-const _ = require('lodash');
 
 describe('cli : domain : handle-dependencies - get-missing-dependencies', () => {
   const scenarios = [
@@ -24,7 +23,7 @@ describe('cli : domain : handle-dependencies - get-missing-dependencies', () => 
     }
   ];
 
-  scenarios.forEach((scenario) => {
+  scenarios.forEach(scenario => {
     const { dependencies, installed, output } = scenario;
     describe(`When dependencies: ${JSON.stringify(
       dependencies
@@ -34,7 +33,7 @@ describe('cli : domain : handle-dependencies - get-missing-dependencies', () => 
       const getMissingDependencies = injectr(
         '../../src/cli/domain/handle-dependencies/get-missing-dependencies.js',
         {
-          '../../../utils/module-exists': (name) => {
+          '../../../utils/module-exists': name => {
             moduleExistsSpy(name);
             return installed[name];
           },
@@ -54,10 +53,10 @@ describe('cli : domain : handle-dependencies - get-missing-dependencies', () => 
       it('should resolve the dependency relative to where the oc cli is running', () => {
         pathResolveSpy.args.forEach((pathResolveCall, i) => {
           expect(pathResolveCall[0]).to.equal('node_modules/');
-          expect(pathResolveCall[1]).to.equal(_.keys(dependencies)[i]);
+          expect(pathResolveCall[1]).to.equal(Object.keys(dependencies)[i]);
         });
         moduleExistsSpy.args.forEach((moduleExistsCall, i) => {
-          expect(moduleExistsCall[0]).to.equal(_.keys(dependencies)[i]);
+          expect(moduleExistsCall[0]).to.equal(Object.keys(dependencies)[i]);
         });
       });
     });

--- a/test/unit/cli-domain-handle-dependencies.js
+++ b/test/unit/cli-domain-handle-dependencies.js
@@ -75,7 +75,7 @@ describe('cli : domain : handle-dependencies', () => {
       };
 
       handleDependencies(
-        { components: _.keys(components), logger },
+        { components: Object.keys(components), logger },
         (err, res) => {
           error = err;
           result = res;


### PR DESCRIPTION
`_.keys` and `_.values` are equivalent to `Object.keys` and `Object.values`, which both are supported in Node 10, so we are replacing those.