### PR TITLE
add default empty object for object keys

### DIFF
--- a/src/registry/domain/url-builder.js
+++ b/src/registry/domain/url-builder.js
@@ -49,7 +49,7 @@ const build = {
 
     return href;
   },
-  queryString: function(parameters) {
+  queryString: function(parameters = {}) {
     let qs = '';
 
     if (Object.keys(parameters).length > 0) {

--- a/src/registry/domain/validators/component-parameters.js
+++ b/src/registry/domain/validators/component-parameters.js
@@ -71,7 +71,7 @@ module.exports = function(requestParameters, expectedParameters) {
   result.errors.message = (function() {
     let errorString = '';
 
-    if (Object.keys(result.errors.mandatory).length > 0) {
+    if (Object.keys(result.errors.mandatory || {}).length > 0) {
       const missingParams = _.map(
         result.errors.mandatory,
         (mandatoryParameter, mandatoryParameterName) =>
@@ -85,7 +85,7 @@ module.exports = function(requestParameters, expectedParameters) {
       );
     }
 
-    if (Object.keys(result.errors.types).length > 0) {
+    if (Object.keys(result.errors.types || {}).length > 0) {
       if (errorString.length > 0) {
         errorString += '; ';
       }

--- a/src/registry/routes/component-info.js
+++ b/src/registry/routes/component-info.js
@@ -12,7 +12,7 @@ function getParams(component) {
   let params = {};
   if (component.oc.parameters) {
     const mandatoryParams = _.filter(
-      Object.keys(component.oc.parameters),
+      Object.keys(component.oc.parameters || {}),
       paramName => {
         const param = component.oc.parameters[paramName];
         return !!param.mandatory && !!param.example;
@@ -61,7 +61,7 @@ function componentInfo(err, req, res, component) {
       res.send(
         infoView({
           component,
-          dependencies: Object.keys(component.dependencies),
+          dependencies: Object.keys(component.dependencies || {}),
           href,
           parsedAuthor,
           repositoryUrl,

--- a/src/registry/routes/component-preview.js
+++ b/src/registry/routes/component-preview.js
@@ -25,7 +25,7 @@ function componentPreview(err, req, res, component, templates) {
     return res.send(
       previewView({
         component,
-        dependencies: Object.keys(component.dependencies),
+        dependencies: Object.keys(component.dependencies || {}),
         href: res.conf.baseUrl,
         liveReload,
         qs: urlBuilder.queryString(req.query),


### PR DESCRIPTION
_.keys() worked with `undefined` but `Object.keys` doesn't, so this adds defaults when needed