### PR TITLE
[BUGFIX] Add back --prefix when installing dependencies

### DIFF
--- a/src/cli/domain/handle-dependencies/install-compiler.ts
+++ b/src/cli/domain/handle-dependencies/install-compiler.ts
@@ -21,7 +21,8 @@ export default function installCompiler(
     dependency,
     installPath: componentPath,
     save: false,
-    silent: true
+    silent: true,
+    usePrefix: false
   };
 
   npm.installDependency(npmOptions, err => {

--- a/src/cli/domain/handle-dependencies/install-missing-dependencies.ts
+++ b/src/cli/domain/handle-dependencies/install-missing-dependencies.ts
@@ -23,7 +23,8 @@ export default function installMissingDependencies(
     dependencies: missing,
     installPath: path.resolve('.'),
     save: false,
-    silent: true
+    silent: true,
+    usePrefix: true
   };
 
   npm.installDependencies(npmOptions, err => {

--- a/src/cli/domain/init-template/install-template.ts
+++ b/src/cli/domain/init-template/install-template.ts
@@ -22,7 +22,8 @@ export default function installTemplate(
     dependency: compiler,
     installPath: componentPath,
     isDev: true,
-    save: true
+    save: true,
+    usePrefix: false
   };
 
   logger.log(strings.messages.cli.installCompiler(compiler));

--- a/src/utils/npm-utils.ts
+++ b/src/utils/npm-utils.ts
@@ -8,8 +8,13 @@ const buildInstallCommand = (options: {
   installPath: string;
   save?: boolean;
   isDev?: boolean;
+  usePrefix: boolean;
 }) => {
   const args = ['install'];
+
+  if (options.usePrefix) {
+    args.push('--prefix', options.installPath);
+  }
 
   if (options.save) {
     args.push('--save-exact');
@@ -54,7 +59,12 @@ export const init = (
 };
 
 export const installDependencies = (
-  options: { dependencies: string[]; installPath: string; silent: boolean },
+  options: {
+    dependencies: string[];
+    installPath: string;
+    silent: boolean;
+    usePrefix: boolean;
+  },
   callback: Callback<{ dest: string }, string | number>
 ): void => {
   const { dependencies, installPath, silent } = options;
@@ -75,7 +85,12 @@ export const installDependencies = (
 };
 
 export const installDependency = (
-  options: { dependency: string; installPath: string; silent?: boolean },
+  options: {
+    dependency: string;
+    installPath: string;
+    silent?: boolean;
+    usePrefix: boolean;
+  },
   callback: Callback<{ dest: string }, string | number>
 ): void => {
   const { dependency, installPath, silent } = options;

--- a/test/unit/cli-domain-handle-dependencies-install-compiler.js
+++ b/test/unit/cli-domain-handle-dependencies-install-compiler.js
@@ -56,7 +56,8 @@ describe('cli : domain : handle-dependencies : install-compiler', () => {
         dependency: 'oc-template-react-compiler@1.2.3',
         installPath: '/path/to/components/component/',
         save: false,
-        silent: true
+        silent: true,
+        usePrefix: false
       });
     });
 

--- a/test/unit/cli-domain-handle-dependencies-install-missing-dependencies.js
+++ b/test/unit/cli-domain-handle-dependencies-install-missing-dependencies.js
@@ -82,7 +82,8 @@ describe('cli : domain : handle-dependencies : install-missing-dependencies', ()
         dependencies: ['lodash@1.2.3', 'underscore@latest'],
         installPath: '/path/to/oc-running',
         save: false,
-        silent: true
+        silent: true,
+        usePrefix: true
       });
     });
 

--- a/test/unit/cli-domain-init-template-install-template.js
+++ b/test/unit/cli-domain-init-template-install-template.js
@@ -46,7 +46,8 @@ describe('cli : domain : init-template : install-template', () => {
         dependency: 'oc-template-jade-compiler',
         installPath: 'path/to/component',
         isDev: true,
-        save: true
+        save: true,
+        usePrefix: false
       });
     });
 


### PR DESCRIPTION
Apparently, for some reason still unknown to me, when calling `publish` inside a build agent, doing a npm install without the prefix may not create a node_modules folder (could not reproduce in local, but I could on Azure Devops), when you call `npx oc publish` on a folder that does not have a package.json.

For this reason I'm adding the option to choose whether to add the `--prefix` or not. It will be added when installing missing dependencies (used by publish and dev), but not when installing the template or the compiler (so it still works correctly without nesting node_modules), because installing the template will always do `npm init` first