### PR TITLE
move nested renderer to promises

### DIFF
--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -22,7 +22,7 @@ import { Config, Repository } from '../../../types';
 import { IncomingHttpHeaders } from 'http';
 import { fromPromise } from 'universalify';
 
-interface Options {
+export interface RendererOptions {
   conf: Config;
   headers: IncomingHttpHeaders;
   ip: string;
@@ -32,7 +32,7 @@ interface Options {
   omitHref?: boolean;
 }
 
-export type GetComponentResult = {
+export interface GetComponentResult {
   status: number;
   headers?: Dictionary<string>;
   response: {
@@ -40,6 +40,7 @@ export type GetComponentResult = {
     code?: string;
     error?: unknown;
     version?: string;
+    html?: string;
     requestVersion?: string;
     name?: string;
     details?: {
@@ -50,7 +51,7 @@ export type GetComponentResult = {
     missingPlugins?: string[];
     missingDependencies?: string[];
   };
-};
+}
 
 export default function getComponent(conf: Config, repository: Repository) {
   const client = Client({ templates: conf.templates });
@@ -60,7 +61,7 @@ export default function getComponent(conf: Config, repository: Repository) {
   });
 
   const renderer = function (
-    options: Options,
+    options: RendererOptions,
     cb: (result: GetComponentResult) => void
   ) {
     const nestedRenderer = NestedRenderer(renderer, options.conf);
@@ -420,8 +421,8 @@ export default function getComponent(conf: Config, repository: Repository) {
             env: conf.env,
             params,
             plugins: conf.plugins,
-            renderComponent: nestedRenderer.renderComponent,
-            renderComponents: nestedRenderer.renderComponents,
+            renderComponent: fromPromise(nestedRenderer.renderComponent),
+            renderComponents: fromPromise(nestedRenderer.renderComponents),
             requestHeaders: options.headers,
             requestIp: options.ip,
             setEmptyResponse,

--- a/test/unit/registry-domain-nested-renderer.js
+++ b/test/unit/registry-domain-nested-renderer.js
@@ -53,32 +53,6 @@ describe('registry : routes : helpers : nested-renderer', () => {
         });
       });
 
-      describe('when callback empty', () => {
-        beforeEach(() => {
-          initialise();
-        });
-
-        it('should throw an error', () => {
-          const f = function () {
-            nestedRenderer.renderComponent('my-component');
-          };
-          expect(f).to.throw('callback is not valid');
-        });
-      });
-
-      describe('when callback not valid', () => {
-        beforeEach(() => {
-          initialise();
-        });
-
-        it('should throw an error', () => {
-          const f = function () {
-            nestedRenderer.renderComponent('my-component', {}, 'blarg');
-          };
-          expect(f).to.throw('callback is not valid');
-        });
-      });
-
       describe('when requesting a not existent component', () => {
         let error;
         beforeEach(done => {
@@ -89,10 +63,10 @@ describe('registry : routes : helpers : nested-renderer', () => {
             }
           });
 
-          nestedRenderer.renderComponent('404-component', {}, err => {
-            error = err;
-            done();
-          });
+          nestedRenderer
+            .renderComponent('404-component', {})
+            .catch(err => (error = err))
+            .finally(done);
         });
 
         it('should return an error in the callback', () => {
@@ -116,22 +90,18 @@ describe('registry : routes : helpers : nested-renderer', () => {
             { bla: 'blabla' }
           );
 
-          nestedRenderer.renderComponent(
-            'my-component',
-            {
+          nestedRenderer
+            .renderComponent('my-component', {
               headers: {
                 'accept-language': 'en-GB',
                 accept: 'blargh'
               },
               parameters: { a: 1234 },
               version: '1.2.X'
-            },
-            (err, res) => {
-              result = res;
-              error = err;
-              done();
-            }
-          );
+            })
+            .then(res => (result = res))
+            .catch(err => (error = err))
+            .finally(done);
         });
 
         it('should get the html result', () => {
@@ -141,6 +111,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
         it('should make correct request to renderer', () => {
           expect(renderer.args[0][0]).to.eql({
             name: 'my-component',
+            ip: '',
             conf: { bla: 'blabla' },
             headers: {
               'accept-language': 'en-GB',
@@ -152,7 +123,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
         });
 
         it('should get no error', () => {
-          expect(error).to.be.null;
+          expect(error).to.be.undefined;
         });
       });
 
@@ -170,11 +141,11 @@ describe('registry : routes : helpers : nested-renderer', () => {
             { bla: 'blabla' }
           );
 
-          nestedRenderer.renderComponent('my-component', (err, res) => {
-            result = res;
-            error = err;
-            done();
-          });
+          nestedRenderer
+            .renderComponent('my-component')
+            .then(res => (result = res))
+            .catch(err => (error = err))
+            .finally(done);
         });
 
         it('should get the html result', () => {
@@ -184,6 +155,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
         it('should make correct request to renderer', () => {
           expect(renderer.args[0][0]).to.eql({
             name: 'my-component',
+            ip: '',
             conf: { bla: 'blabla' },
             headers: {
               accept: 'application/vnd.oc.rendered+json'
@@ -194,7 +166,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
         });
 
         it('should get no error', () => {
-          expect(error).to.be.null;
+          expect(error).to.be.undefined;
         });
       });
     });
@@ -228,32 +200,6 @@ describe('registry : routes : helpers : nested-renderer', () => {
         });
       });
 
-      describe('when callback empty', () => {
-        beforeEach(() => {
-          initialise();
-        });
-
-        it('should throw an error', () => {
-          const f = function () {
-            nestedRenderer.renderComponents([{ name: 'my-component' }]);
-          };
-          expect(f).to.throw('callback is not valid');
-        });
-      });
-
-      describe('when callback not valid', () => {
-        beforeEach(() => {
-          initialise();
-        });
-
-        it('should throw an error', () => {
-          const f = function () {
-            nestedRenderer.renderComponents(['my-component'], {}, 'blarg');
-          };
-          expect(f).to.throw('callback is not valid');
-        });
-      });
-
       describe('when requesting not existent components', () => {
         let result;
         let error;
@@ -265,22 +211,27 @@ describe('registry : routes : helpers : nested-renderer', () => {
             }
           });
 
-          nestedRenderer.renderComponents(
-            [
-              { name: '404-component' },
-              { name: 'another-not-existent-component' }
-            ],
-            {},
-            (err, res) => {
+          nestedRenderer
+            .renderComponents(
+              [
+                { name: '404-component' },
+                { name: 'another-not-existent-component' }
+              ],
+              {}
+            )
+            .then(res => {
+              console.log('RES:', res);
               result = res;
+            })
+            .catch(err => {
+              console.log('HI:', err);
               error = err;
-              done();
-            }
-          );
+            })
+            .finally(done);
         });
 
         it('should return no error in the callback', () => {
-          expect(error).to.be.null;
+          expect(error).to.be.undefined;
         });
 
         it('should return error in result callback', () => {
@@ -309,35 +260,34 @@ describe('registry : routes : helpers : nested-renderer', () => {
             { bla: 'blabla' }
           );
 
-          nestedRenderer.renderComponents(
-            [
+          nestedRenderer
+            .renderComponents(
+              [
+                {
+                  name: 'my-component',
+                  parameters: { x: 123 },
+                  version: '1.2.X'
+                },
+                {
+                  name: 'my-other-component',
+                  parameters: { y: 456 },
+                  version: '^1.4.6'
+                }
+              ],
               {
-                name: 'my-component',
-                parameters: { x: 123 },
-                version: '1.2.X'
-              },
-              {
-                name: 'my-other-component',
-                parameters: { y: 456 },
-                version: '^1.4.6'
+                headers: {
+                  'accept-language': 'en-GB',
+                  accept: 'blargh'
+                },
+                parameters: {
+                  x: 456,
+                  z: 789
+                }
               }
-            ],
-            {
-              headers: {
-                'accept-language': 'en-GB',
-                accept: 'blargh'
-              },
-              parameters: {
-                x: 456,
-                z: 789
-              }
-            },
-            (err, res) => {
-              result = res;
-              error = err;
-              done();
-            }
-          );
+            )
+            .then(res => (result = res))
+            .catch(err => (error = err))
+            .finally(done);
         });
 
         it('should get the html result', () => {
@@ -349,6 +299,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
 
           expect(renderer.args[0][0]).to.eql({
             name: 'my-component',
+            ip: '',
             conf: { bla: 'blabla' },
             headers: {
               'accept-language': 'en-GB',
@@ -363,6 +314,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
 
           expect(renderer.args[1][0]).to.eql({
             name: 'my-other-component',
+            ip: '',
             conf: { bla: 'blabla' },
             headers: {
               'accept-language': 'en-GB',
@@ -378,7 +330,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
         });
 
         it('should get no error', () => {
-          expect(error).to.be.null;
+          expect(error).to.be.undefined;
         });
       });
 
@@ -400,14 +352,14 @@ describe('registry : routes : helpers : nested-renderer', () => {
             { bla: 'blabla' }
           );
 
-          nestedRenderer.renderComponents(
-            [{ name: 'my-component' }, { name: 'my-other-component' }],
-            (err, res) => {
-              result = res;
-              error = err;
-              done();
-            }
-          );
+          nestedRenderer
+            .renderComponents([
+              { name: 'my-component' },
+              { name: 'my-other-component' }
+            ])
+            .then(res => (result = res))
+            .catch(err => (error = err))
+            .finally(done);
         });
 
         it('should get the html result', () => {
@@ -419,6 +371,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
 
           expect(renderer.args[0][0]).to.eql({
             name: 'my-component',
+            ip: '',
             conf: { bla: 'blabla' },
             headers: { accept: 'application/vnd.oc.rendered+json' },
             parameters: {},
@@ -427,6 +380,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
 
           expect(renderer.args[1][0]).to.eql({
             name: 'my-other-component',
+            ip: '',
             conf: { bla: 'blabla' },
             headers: { accept: 'application/vnd.oc.rendered+json' },
             parameters: {},
@@ -435,7 +389,7 @@ describe('registry : routes : helpers : nested-renderer', () => {
         });
 
         it('should get no error', () => {
-          expect(error).to.be.null;
+          expect(error).to.be.undefined;
         });
       });
     });


### PR DESCRIPTION
Transforming nested-renderer to promises. When exported in get-component they will be universalified, because they are exported on the ocs, so to not break we need to keep supporting callback cased calls