### PR TITLE
[INTERNAL] replace deprecated new Buffer to Buffer.from

### DIFF
--- a/src/cli/domain/registry.ts
+++ b/src/cli/domain/registry.ts
@@ -126,7 +126,7 @@ export default function registry(opts: RegistryOptions = {}): RegistryCli {
         requestsHeaders = Object.assign(requestsHeaders, {
           Authorization:
             'Basic ' +
-            new Buffer(options.username + ':' + options.password).toString(
+            Buffer.from(options.username + ':' + options.password).toString(
               'base64'
             )
         });


### PR DESCRIPTION
Since `new Buffer` is deprecated, using `Buffer.from`