### PR TITLE
[CLI-FEATURE] filter components to run when running oc dev

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -52,6 +52,10 @@ export default {
           boolean: false,
           description: 'Url prefix for registry server',
           default: ''
+        },
+        components: {
+          array: true,
+          description: 'Filter only the components that you want to be included'
         }
       },
       usage: 'Usage: $0 dev <dirPath> [port] [baseUrl] [options]'

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -55,7 +55,8 @@ export default {
         },
         components: {
           array: true,
-          description: 'Filter only the components that you want to be included'
+          description:
+            'List of component names that you want to be packaged and exposed on dev registry'
         }
       },
       usage: 'Usage: $0 dev <dirPath> [port] [baseUrl] [options]'

--- a/src/cli/domain/get-components-by-dir.ts
+++ b/src/cli/domain/get-components-by-dir.ts
@@ -3,7 +3,20 @@ import path from 'path';
 import { Component } from '../../types';
 
 export default function getComponentsByDir() {
-  return (componentsDir: string, callback: Callback<string[]>): void => {
+  return (
+    componentsDir: string,
+    componentsToRunOrCb: string[] | Callback<string[]>,
+    callbackMaybe?: Callback<string[]>
+  ): void => {
+    const componentsToRun =
+      typeof componentsToRunOrCb === 'function'
+        ? undefined
+        : componentsToRunOrCb;
+    const callback =
+      typeof componentsToRunOrCb === 'function'
+        ? componentsToRunOrCb
+        : callbackMaybe!;
+
     const isOcComponent = function (file: string) {
       const filePath = path.resolve(componentsDir, file);
       const packagePath = path.join(filePath, 'package.json');
@@ -28,6 +41,11 @@ export default function getComponentsByDir() {
 
     try {
       dirContent = fs.readdirSync(componentsDir);
+      if (componentsToRun) {
+        dirContent = dirContent.filter(content =>
+          componentsToRun.includes(content)
+        );
+      }
     } catch (err) {
       return callback(null, []);
     }

--- a/src/cli/facade/dev.ts
+++ b/src/cli/facade/dev.ts
@@ -140,7 +140,7 @@ const dev =
     logger.warn(cliMessages.SCANNING_COMPONENTS, true);
     local.getComponentsByDir(
       componentsDir,
-      opts.components,
+      opts.components as any,
       (err, components) => {
         if (_.isEmpty(components)) {
           err = cliErrors.DEV_FAIL(cliErrors.COMPONENTS_NOT_FOUND) as any;

--- a/src/cli/facade/dev.ts
+++ b/src/cli/facade/dev.ts
@@ -28,6 +28,7 @@ const dev =
       baseUrl: string;
       fallbackRegistryUrl: string;
       hotReloading?: boolean;
+      components: string[];
       watch?: boolean;
       verbose?: boolean;
       production?: boolean;
@@ -137,96 +138,101 @@ const dev =
     };
 
     logger.warn(cliMessages.SCANNING_COMPONENTS, true);
-    local.getComponentsByDir(componentsDir, (err, components) => {
-      if (_.isEmpty(components)) {
-        err = cliErrors.DEV_FAIL(cliErrors.COMPONENTS_NOT_FOUND) as any;
-        callback(err, undefined as any);
-        return logger.err(String(err));
-      }
-
-      logger.ok('OK');
-      _.forEach(components, component =>
-        logger.log(colors.green('├── ') + component)
-      );
-
-      handleDependencies({ components, logger }, (err, dependencies) => {
-        if (err) {
-          logger.err(err);
-          return callback(err, undefined as any);
+    local.getComponentsByDir(
+      componentsDir,
+      opts.components,
+      (err, components) => {
+        if (_.isEmpty(components)) {
+          err = cliErrors.DEV_FAIL(cliErrors.COMPONENTS_NOT_FOUND) as any;
+          callback(err, undefined as any);
+          return logger.err(String(err));
         }
-        packageComponents(components, () => {
-          async.waterfall(
-            [
-              (next: any) => {
-                if (hotReloading) {
-                  getPort(port + 1, (error, otherPort) => {
-                    if (error) {
-                      return next(error);
-                    }
-                    const liveReloadServer = livereload.createServer({
-                      port: otherPort
+
+        logger.ok('OK');
+        _.forEach(components, component =>
+          logger.log(colors.green('├── ') + component)
+        );
+
+        handleDependencies({ components, logger }, (err, dependencies) => {
+          if (err) {
+            logger.err(err);
+            return callback(err, undefined as any);
+          }
+          packageComponents(components, () => {
+            async.waterfall(
+              [
+                (next: any) => {
+                  if (hotReloading) {
+                    getPort(port + 1, (error, otherPort) => {
+                      if (error) {
+                        return next(error);
+                      }
+                      const liveReloadServer = livereload.createServer({
+                        port: otherPort
+                      });
+                      const refresher = () => liveReloadServer.refresh('/');
+                      next(null, { refresher, port: otherPort });
                     });
-                    const refresher = () => liveReloadServer.refresh('/');
-                    next(null, { refresher, port: otherPort });
-                  });
-                } else {
-                  next(null, { refresher: _.noop, port: null });
-                }
-              }
-            ],
-            (err, liveReload: any) => {
-              if (err) {
-                logger.err(String(err));
-                return callback(err, undefined as any);
-              }
-
-              const registry = oc.Registry({
-                baseUrl,
-                prefix: opts.prefix || '',
-                dependencies: dependencies.modules,
-                discovery: true,
-                env: { name: 'local' },
-                fallbackRegistryUrl,
-                hotReloading,
-                liveReloadPort: liveReload.port,
-                local: true,
-                path: path.resolve(componentsDir),
-                port,
-                templates: dependencies.templates,
-                verbosity: 1
-              });
-
-              registerPlugins(registry);
-
-              logger.warn(cliMessages.REGISTRY_STARTING(baseUrl));
-              if (liveReload.port) {
-                logger.warn(
-                  cliMessages.REGISTRY_LIVERELOAD_STARTING(liveReload.port)
-                );
-              }
-              registry.start(err => {
-                if (err) {
-                  if ((err as any).code === 'EADDRINUSE') {
-                    err = cliErrors.PORT_IS_BUSY(port) as any;
+                  } else {
+                    next(null, { refresher: _.noop, port: null });
                   }
-
+                }
+              ],
+              (err, liveReload: any) => {
+                if (err) {
                   logger.err(String(err));
                   return callback(err, undefined as any);
                 }
 
-                if (optWatch) {
-                  watchForChanges(
-                    { components, refreshLiveReload: liveReload.refresher },
-                    packageComponents
+                const registry = oc.Registry({
+                  baseUrl,
+                  prefix: opts.prefix || '',
+                  dependencies: dependencies.modules,
+                  discovery: true,
+                  env: { name: 'local' },
+                  fallbackRegistryUrl,
+                  hotReloading,
+                  liveReloadPort: liveReload.port,
+                  local: true,
+                  components: opts.components,
+                  path: path.resolve(componentsDir),
+                  port,
+                  templates: dependencies.templates,
+                  verbosity: 1
+                });
+
+                registerPlugins(registry);
+
+                logger.warn(cliMessages.REGISTRY_STARTING(baseUrl));
+                if (liveReload.port) {
+                  logger.warn(
+                    cliMessages.REGISTRY_LIVERELOAD_STARTING(liveReload.port)
                   );
                 }
-                callback(null, registry);
-              });
-            }
-          );
+                registry.start(err => {
+                  if (err) {
+                    if ((err as any).code === 'EADDRINUSE') {
+                      err = cliErrors.PORT_IS_BUSY(port) as any;
+                    }
+
+                    logger.err(String(err));
+                    return callback(err, undefined as any);
+                  }
+
+                  if (optWatch) {
+                    watchForChanges(
+                      { components, refreshLiveReload: liveReload.refresher },
+                      packageComponents
+                    );
+                  }
+                  callback(null, registry);
+                });
+              }
+            );
+          });
         });
-      });
-    });
+      }
+    );
   };
 
 export default dev;

--- a/src/registry/domain/repository.ts
+++ b/src/registry/domain/repository.ts
@@ -58,16 +58,18 @@ export default function repository(conf: Config): Repository {
         .toString();
     },
     getComponents(): string[] {
-      const validComponents = fs.readdirSync(conf.path).filter(file => {
-        const isDir = fs.lstatSync(path.join(conf.path, file)).isDirectory();
-        const isValidComponent = isDir
-          ? fs
-              .readdirSync(path.join(conf.path, file))
-              .filter(file => file === '_package').length === 1
-          : false;
+      const validComponents =
+        conf.components ||
+        fs.readdirSync(conf.path).filter(file => {
+          const isDir = fs.lstatSync(path.join(conf.path, file)).isDirectory();
+          const isValidComponent = isDir
+            ? fs
+                .readdirSync(path.join(conf.path, file))
+                .filter(file => file === '_package').length === 1
+            : false;
 
-        return isValidComponent;
-      });
+          return isValidComponent;
+        });
 
       validComponents.push('oc-client');
       return validComponents;

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,7 @@ export interface Config {
   hotReloading: boolean;
   keepAliveTimeout?: number;
   liveReloadPort: number;
+  components?: string[];
   local: boolean;
   path: string;
   plugins: Record<string, (...args: unknown[]) => void>;
@@ -271,6 +272,7 @@ export interface Local {
   ) => void;
   getComponentsByDir: (
     componentsDir: string,
+    componentsToRun: Callback<string[]> | string[],
     callback: Callback<string[]>
   ) => void;
   init: (


### PR DESCRIPTION
When running `oc dev` on a folder, it will try to register and package all the oc components that it can find, but that sometimes can be undesirable on the following circumstances:

1) You don't want to have to package multiple components that you are not testing at that moment (more time compiling).
2) You want some of those components to be retreived from a fallback registry.

For that, I'm adding a new option `--components` in `oc dev` that takes a list of folders to run against. So given that you are on a folder with

`component1, component2, component3, component4`

When running the command

`oc dev . --components component1 component3`

It will only package and show on the local registry the components 1 and 3.