### PR TITLE
[CLI-FEATURE] add registries options for oc publish

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -132,7 +132,7 @@ export default {
         registries: {
           array: true,
           description:
-            'registries to publish, overriding your configuration in oc.json'
+            'List of registries to publish to. This setting will take precedence over oc.json file'
         }
       },
       description: 'Publish a component',

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -128,6 +128,11 @@ export default {
           boolean: true,
           description: 'Skip packaging step',
           default: false
+        },
+        registries: {
+          array: true,
+          description:
+            'registries to publish, overriding your configuration in oc.json'
         }
       },
       description: 'Publish a component',

--- a/src/cli/facade/publish.ts
+++ b/src/cli/facade/publish.ts
@@ -26,6 +26,7 @@ const publish =
       skipPackage?: boolean;
       username?: string;
       password?: string;
+      registries?: string[];
     },
     callback: (err?: Error | string) => void
   ): void => {
@@ -83,6 +84,14 @@ const publish =
           cb(null, component);
         });
       });
+    };
+
+    const getRegistries = (
+      cb: (err: string | null, registryLocations: string[]) => void
+    ): void => {
+      if (opts.registries) return cb(null, opts.registries);
+
+      registry.get(cb);
     };
 
     const putComponentToRegistry = (
@@ -175,7 +184,7 @@ const publish =
       );
     };
 
-    registry.get((err: string | null, registryLocations: string[]) => {
+    getRegistries((err: string | null, registryLocations: string[]) => {
       if (err) {
         logger.err(err);
         return callback(err);

--- a/test/unit/cli-facade-publish.js
+++ b/test/unit/cli-facade-publish.js
@@ -102,7 +102,7 @@ describe('cli : facade : publish', () => {
         });
       });
 
-      it('should take precedence the registries set through options', done => {
+      it('should take precedence over the registries set through oc.json', done => {
         sinon.stub(registry, 'putComponent').yields(null, 'ok');
         execute(
           () => {

--- a/test/unit/cli-facade-publish.js
+++ b/test/unit/cli-facade-publish.js
@@ -20,7 +20,7 @@ describe('cli : facade : publish', () => {
 
   const execute = function (
     cb,
-    { creds = {}, skipPackage = false, fs = {} } = {}
+    { creds = {}, skipPackage = false, fs = {}, registries } = {}
   ) {
     logSpy.err = sinon.stub();
     logSpy.log = sinon.stub();
@@ -47,7 +47,8 @@ describe('cli : facade : publish', () => {
         componentPath: 'test/fixtures/components/hello-world/',
         username: creds.username,
         password: creds.password,
-        skipPackage
+        skipPackage,
+        registries
       },
       () => {
         cb();
@@ -99,6 +100,20 @@ describe('cli : facade : publish', () => {
           );
           done();
         });
+      });
+
+      it('should take precedence the registries set through options', done => {
+        sinon.stub(registry, 'putComponent').yields(null, 'ok');
+        execute(
+          () => {
+            registry.putComponent.restore();
+
+            expect(logSpy.ok.args[0][0]).to.include('http://www.newapi.com');
+            expect(logSpy.ok.args[1][0]).to.include('http://www.newapi2.com');
+            done();
+          },
+          { registries: ['http://www.newapi.com', 'http://www.newapi2.com'] }
+        );
       });
 
       describe('when packaging', () => {


### PR DESCRIPTION
Right now, to publish to registries you need to have set a `oc.json` file with your registries. This works well when you only publish to one registry, or you always publish to all the registries at the same time (so you can have your oc.json versioned in your repo and just use it).

The problem is that that solution doesn't work as well when your deployment setup is to publish to a different registry depending on your environment (1 or more registries on each environment). In that case, for every deployment, you have to go and edit the oc.json before being able to call `oc publish`.

For those cases, I'm adding a new option `--registries` that allows you to pass a list of registries that will override your oc.json configuration. So when you want to publish you can just do

```
oc publish your-component --registries http://www.myregistry.com https://www.myregistry2.com
```
without needing a oc.json