### PR TITLE
add "open" link to component preview page

### DIFF
--- a/src/registry/views/info.ts
+++ b/src/registry/views/info.ts
@@ -73,8 +73,11 @@ export default function info(vm: Vm): string {
     <div class="field"><p>Accept-Language header:</p></div>
     <input class="w-100" id="lang" type="text" value="*" />
     <h3>
-      Preview
-      <a class="refresh-preview" href="#refresh">(Refresh)</a>
+      Preview (
+      <a class="refresh-preview" href="#refresh">Refresh</a>
+      |
+      <a class="open-preview" href="#open">Open</a>
+      )
     </h3>
     <iframe class="preview" src="~preview/${sandBoxDefaultQs}"></iframe>`;
 

--- a/src/registry/views/static/info.ts
+++ b/src/registry/views/static/info.ts
@@ -7,7 +7,7 @@ oc.cmd.push(function() {
     window.location = thisComponentHref + $(this).val() + '/~info';
   });
 
-  $('.refresh-preview').click(function() {
+  refreshPreview = function() {
     var splitted = $('#href')
         .val()
         .split('?'),
@@ -28,5 +28,16 @@ oc.cmd.push(function() {
     $('.preview').attr('src', url);
 
     return false;
+  };
+  $('.refresh-preview').click(refreshPreview);
+
+  $('.open-preview').click(function() {
+    refreshPreview();
+    var url = $('.preview').attr('src');
+
+    window.open(url, '_blank');
+    return false;
   });
+
+
 });`;

--- a/src/registry/views/static/info.ts
+++ b/src/registry/views/static/info.ts
@@ -7,7 +7,7 @@ oc.cmd.push(function() {
     window.location = thisComponentHref + $(this).val() + '/~info';
   });
 
-  refreshPreview = function() {
+  var refreshPreview = function() {
     var splitted = $('#href')
         .val()
         .split('?'),


### PR DESCRIPTION
Add a "Open" link next to "Preview" to open component preview in a new tab. 

The component preview frame is small and not very usable for testing. I always find myself copying the link, adding "~preview" and pasting it to a new tab. Now the link can do it for me.

![image](https://user-images.githubusercontent.com/365935/146149391-43c02625-f2f8-4eea-b3f3-096449ac2b7f.png)
