### PR TITLE
use polling on watch

### DIFF
--- a/src/cli/domain/watch.ts
+++ b/src/cli/domain/watch.ts
@@ -12,7 +12,7 @@ export default function watch(
     ignored: settings.filesToIgnoreOnDevWatch,
     persistent: true,
     ignoreInitial: true,
-    usePolling: false
+    usePolling: true
   });
   const onChange = (fileName: string) => {
     const componentDir = dirs.find(dir =>


### PR DESCRIPTION
Apparently not polling was causing an issue with the react template, where it would watch for /temp files created, and it would enter into an infinite loop of hot-reloading. Adding polling avoids that it checks for the temp files created when repackaging.