### PR TITLE
dont watch files on temp folder from templates

### DIFF
--- a/src/resources/settings.ts
+++ b/src/resources/settings.ts
@@ -3,7 +3,7 @@ export default {
     src: './oc.json'
   },
   filesToIgnoreOnDevWatch:
-    /node_modules|package\.tar\.gz|_package|\.sw[op]|\.git\/|\.idea\/|\.DS_Store|oc\.json/,
+    /temp\/__oc|node_modules|package\.tar\.gz|_package|\.sw[op]|\.git\/|\.idea\/|\.DS_Store|oc\.json/,
   maxLoopIterations: 1e9,
   registry: {
     acceptRenderedHeader: 'application/vnd.oc.rendered+json',


### PR DESCRIPTION
There is an issue where if templates like oc-template-react goes too fast, the temp file generated during packagin will cause an infinite loop for the watcher, so this change will add any file that has `temp/__oc` as part of the path to be ignored by the watcher. 