### PR TITLE
add option to send custom status code back to the registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "multer": "1.4.3",
     "nice-cache": "0.0.5",
     "oc-client": "4.0.1",
-    "oc-client-browser": "1.5.7",
+    "oc-client-browser": "1.5.8",
     "oc-empty-response-handler": "1.0.2",
     "oc-get-unix-utc-timestamp": "1.0.6",
     "oc-s3-storage-adapter": "1.2.0",

--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -275,7 +275,7 @@ export default function getComponent(conf: Config, repository: Repository) {
               err ||
               new Error(strings.errors.registry.DATA_OBJECT_IS_UNDEFINED);
             return callback({
-              status: 500,
+              status: Number(err.status) || 500,
               response: {
                 code: 'GENERIC_ERROR',
                 error: strings.errors.registry.COMPONENT_EXECUTION_ERROR(

--- a/test/fixtures/mocked-components/async-custom-error.js
+++ b/test/fixtures/mocked-components/async-custom-error.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  package: {
+    name: 'async-custom-error-component',
+    version: '1.0.0',
+    oc: {
+      container: false,
+      renderInfo: false,
+      files: {
+        template: {
+          type: 'jade',
+          hashKey: '8c1fbd954f2b0d8cd5cf11c885fed4805225749f',
+          src: 'template.js'
+        },
+        dataProvider: {
+          type: 'node.js',
+          hashKey: '123457',
+          src: 'server.js'
+        }
+      }
+    }
+  },
+  data: '"use strict";module.exports.data = function(ctx, cb){cb(Object.assign(new Error(), {status: 404}));};',
+  view:
+    'var oc=oc||{};oc.components=oc.components||{},oc.components["8c1fbd954f2b0d8cd5cf11c885fed4805225749f"]' +
+    '=function(){var o=[];return o.push("<div>hello</div>"),o.join("")};'
+};

--- a/test/fixtures/mocked-components/index.js
+++ b/test/fixtures/mocked-components/index.js
@@ -5,6 +5,7 @@ module.exports = {
   'async-error2-component': require('./async-error2'),
   'async-error3-component': require('./async-error3'),
   'async-error4-component': require('./async-error4'),
+  'async-custom-error-component': require('./async-custom-error'),
   'error-component': require('./error'),
   'npm-component': require('./npm'),
   'plugin-component': require('./plugin'),

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -135,6 +135,27 @@ describe('registry : routes : helpers : get-component', () => {
     });
   });
 
+  describe('when the component sends a custom status code', () => {
+    before(done => {
+      initialise(mockedComponents['async-custom-error-component']);
+      const getComponent = GetComponent({}, mockedRepository);
+
+      getComponent(
+        {
+          name: 'async-custom-error-component',
+          headers: {},
+          version: '1.X.X',
+          conf: { baseUrl: 'http://components.com/' }
+        },
+        () => done()
+      );
+    });
+
+    it.only('should return that status code to the client', () => {
+      expect(fireStub.args[0][1].status).to.equal(404);
+    });
+  });
+
   describe('when rendering a component with a legacy template', () => {
     describe("when oc-client requests an unrendered component and it doesn't provide templates header", () => {
       const headers = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,7 +2405,7 @@
   dependencies:
     "prettier-linter-helpers" "^1.0.0"
 
-"eslint-scope@^5.1.1":
+"eslint-scope@^5.1.1", "eslint-scope@5.1.1":
   "integrity" "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="
   "resolved" "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
   "version" "5.1.1"
@@ -2420,14 +2420,6 @@
   dependencies:
     "esrecurse" "^4.3.0"
     "estraverse" "^5.2.0"
-
-"eslint-scope@5.1.1":
-  "integrity" "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="
-  "resolved" "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
-  "version" "5.1.1"
-  dependencies:
-    "esrecurse" "^4.3.0"
-    "estraverse" "^4.1.1"
 
 "eslint-utils@^3.0.0":
   "integrity" "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA=="
@@ -2518,7 +2510,12 @@
   "resolved" "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   "version" "4.3.0"
 
-"estraverse@^5.1.0", "estraverse@^5.2.0":
+"estraverse@^5.1.0":
+  "integrity" "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+  "resolved" "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
+  "version" "5.3.0"
+
+"estraverse@^5.2.0":
   "integrity" "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
   "resolved" "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   "version" "5.3.0"
@@ -3858,10 +3855,10 @@
   "resolved" "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.5.4.tgz"
   "version" "1.5.4"
 
-"oc-client-browser@1.5.7":
-  "integrity" "sha512-TO7FVwJ+FDcrejXWjVkpp1ddgG/7No1nWZGs552iOz8m+Gqfq6ES+d2hnUXz7BtH4GrDr6l9RQwJhci+fqIQtQ=="
-  "resolved" "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.5.7.tgz"
-  "version" "1.5.7"
+"oc-client-browser@1.5.8":
+  "integrity" "sha512-2EKANYx7u0Vm1qYfU328L3P28KzZTTUJB2Dkbic4/WhE+WskBmdPfJyGoufuJBipXygvlqqXQ5lnaZ6Roq0JuQ=="
+  "resolved" "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.5.8.tgz"
+  "version" "1.5.8"
   dependencies:
     "universalify" "2.0.0"
 


### PR DESCRIPTION
Closes #831 

The idea is that if you send a custom error with a `status` property (pretty common in other node HTTP libraries), that will be used on the registry to return that code back to the browser.