### PR TITLE
Add Node.js v18 to CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Add Node.js v18 to CI

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

The Node.js [current](https://github.com/nodejs/release#release-schedule) version is v18, with 14 and 16 in maintenance or LTS. To keep the project up to date, I suggest to also execute the tests on v18.

**Test plan (required)**

Executing both the tests and the build locally shows no errors or warnings.

**Closing issues**

closes #1309 