### PR TITLE
include the entire console api in the production stub

### DIFF
--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -491,7 +491,27 @@ export default function getComponent(conf: Config, repository: Repository) {
                       (...args: unknown[]) => unknown
                     >
                   },
-                  console: conf.local ? console : { log: _.noop },
+                  console: conf.local ? console : {
+                    assert: _.noop,
+                    clear: _.noop,
+                    count: _.noop,
+                    countReset: _.noop,
+                    debug: _.noop,
+                    dir: _.noop,
+                    dirxml: _.noop,
+                    error: _.noop,
+                    group: _.noop,
+                    groupCollapsed: _.noop,
+                    groupEnd: _.noop,
+                    info: _.noop,
+                    log: _.noop,
+                    table: _.noop,
+                    time: _.noop,
+                    timeEnd: _.noop,
+                    timeLog: _.noop,
+                    trace: _.noop,
+                    warn: _.noop,
+                    },
                   setTimeout,
                   Buffer
                 };

--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -491,27 +491,7 @@ export default function getComponent(conf: Config, repository: Repository) {
                       (...args: unknown[]) => unknown
                     >
                   },
-                  console: conf.local ? console : {
-                    assert: _.noop,
-                    clear: _.noop,
-                    count: _.noop,
-                    countReset: _.noop,
-                    debug: _.noop,
-                    dir: _.noop,
-                    dirxml: _.noop,
-                    error: _.noop,
-                    group: _.noop,
-                    groupCollapsed: _.noop,
-                    groupEnd: _.noop,
-                    info: _.noop,
-                    log: _.noop,
-                    table: _.noop,
-                    time: _.noop,
-                    timeEnd: _.noop,
-                    timeLog: _.noop,
-                    trace: _.noop,
-                    warn: _.noop,
-                    },
+                  console: conf.local ? console : Object.fromEntries(Object.keys(console).map(key => [key, _.noop])),
                   setTimeout,
                   Buffer
                 };


### PR DESCRIPTION
Usage of `console.warn` will prevent the entire component from rendering in the production oc-registry. This PR addresses this by fully specifying a `console` stub in production.

<!-- Make sure tests pass on both Travis and AppVeyor. -->

**Closing issues**
closes #1316 
