### PR TITLE
make npmignore applied only to root folders

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,6 @@
 .travis.yml
 appveyor.yml
 Gruntfile.js
-tasks
-test
-src
+/tasks
+/test
+/src


### PR DESCRIPTION
Last PR introduced a bug by using "src" on .npmignore instead of "/src", because it went and ignored the nested "src" folder of the oc-client, which makes publishing it not upload the src files.

This fixes it for this and the rest of root folders