### PR TITLE
showing all error when publishing fails

### DIFF
--- a/src/registry/routes/publish.ts
+++ b/src/registry/routes/publish.ts
@@ -64,20 +64,28 @@ export default function publish(repository: Repository) {
         );
         res.status(200).json({ ok: true });
       } catch (err: any) {
+        let errorMessage;
+        if(err.msg) {
+          errorMessage = err.msg;
+        } else if (err.message){
+          errorMessage = err.message;
+        } else {
+          errorMessage = JSON.stringify(err);
+        }
         if (err.code === 'not_allowed') {
-          res.errorDetails = `Publish not allowed: ${err}`;
+          res.errorDetails = `Publish not allowed: ${errorMessage}`;
           res.status(403).json({ error: err });
         } else if (err.code === 'already_exists') {
-          res.errorDetails = `Component already exists: ${err}`;
+          res.errorDetails = `Component already exists: ${errorMessage}`;
           res.status(403).json({ error: err });
         } else if (err.code === 'name_not_valid') {
-          res.errorDetails = `Component name not valid: ${err}`;
+          res.errorDetails = `Component name not valid: ${errorMessage}`;
           res.status(409).json({ error: err });
         } else if (err.code === 'version_not_valid') {
-          res.errorDetails = `Component version not valid: ${err}`;
+          res.errorDetails = `Component version not valid: ${errorMessage}`;
           res.status(409).json({ error: err });
         } else {
-          res.errorDetails = `Publish failed: ${err}`;
+          res.errorDetails = `Publish failed: ${errorMessage}`;
           res.status(500).json({ error: err });
         }
       }

--- a/src/registry/routes/publish.ts
+++ b/src/registry/routes/publish.ts
@@ -65,20 +65,20 @@ export default function publish(repository: Repository) {
         res.status(200).json({ ok: true });
       } catch (err: any) {
         if (err.code === 'not_allowed') {
-          res.errorDetails = `Publish not allowed: ${err.msg}`;
-          res.status(403).json({ error: err.msg });
+          res.errorDetails = `Publish not allowed: ${err}`;
+          res.status(403).json({ error: err });
         } else if (err.code === 'already_exists') {
-          res.errorDetails = `Component already exists: ${err.msg}`;
-          res.status(403).json({ error: err.msg });
+          res.errorDetails = `Component already exists: ${err}`;
+          res.status(403).json({ error: err });
         } else if (err.code === 'name_not_valid') {
-          res.errorDetails = `Component name not valid: ${err.msg}`;
-          res.status(409).json({ error: err.msg });
+          res.errorDetails = `Component name not valid: ${err}`;
+          res.status(409).json({ error: err });
         } else if (err.code === 'version_not_valid') {
-          res.errorDetails = `Component version not valid: ${err.msg}`;
-          res.status(409).json({ error: err.msg });
+          res.errorDetails = `Component version not valid: ${err}`;
+          res.status(409).json({ error: err });
         } else {
-          res.errorDetails = `Publish failed: ${err.msg}`;
-          res.status(500).json({ error: err.msg });
+          res.errorDetails = `Publish failed: ${err}`;
+          res.status(500).json({ error: err });
         }
       }
     } catch (err) {

--- a/src/registry/routes/publish.ts
+++ b/src/registry/routes/publish.ts
@@ -65,13 +65,13 @@ export default function publish(repository: Repository) {
         res.status(200).json({ ok: true });
       } catch (err: any) {
         let errorMessage;
-        if(err.msg) {
+        if(res.conf.local){
+          errorMessage = JSON.stringify(err);
+        }else if(err.msg) {
           errorMessage = err.msg;
         } else if (err.message){
           errorMessage = err.message;
-        } else {
-          errorMessage = JSON.stringify(err);
-        }
+        } 
         if (err.code === 'not_allowed') {
           res.errorDetails = `Publish not allowed: ${errorMessage}`;
           res.status(403).json({ error: err });


### PR DESCRIPTION
Relates to #1326 

Explain the **details** for making this change. What existing problem does the pull request solve?
- Putting the whole error object in error response when publishing fails.
This is to avoid empty error responses as mentioned in issue.

`closes #1326 `.
