### PR TITLE
send data-provider-error event

### DIFF
--- a/src/registry/domain/events-handler.ts
+++ b/src/registry/domain/events-handler.ts
@@ -30,6 +30,14 @@ type Events = {
     requestVersion: string;
     duration: number;
   };
+  'data-provider-error': {
+    name: string;
+    version: string;
+    parameters: Record<string, string | boolean | number>;
+    requestVersion: string;
+    status: number;
+    error: Error;
+  };
 };
 
 type EventsHandler = {

--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -295,8 +295,19 @@ export default function getComponent(conf: Config, repository: Repository) {
             err =
               err ||
               new Error(strings.errors.registry.DATA_OBJECT_IS_UNDEFINED);
+            const status = Number(err.status) || 500;
+
+            eventsHandler.fire('data-provider-error', {
+              status,
+              name: component.name,
+              requestVersion: requestedComponent.version,
+              parameters: params,
+              version: component.version,
+              error: err
+            });
+
             return callback({
-              status: Number(err.status) || 500,
+              status,
               response: {
                 code: 'GENERIC_ERROR',
                 error: strings.errors.registry.COMPONENT_EXECUTION_ERROR(

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -125,18 +125,20 @@ describe('registry : routes : helpers : get-component', () => {
     });
 
     it('should fire a component-retrieved event', () => {
-      expect(fireStub.args[0][0]).to.equal('component-retrieved');
-      expect(fireStub.args[0][1].headers).to.eql({});
-      expect(fireStub.args[0][1].name).to.equal('async-error2-component');
-      expect(fireStub.args[0][1].parameters).to.eql({});
-      expect(fireStub.args[0][1].requestVersion).to.equal('1.X.X');
-      expect(fireStub.args[0][1].href).to.equal(
+      const [eventName, eventData] = fireStub.args[0];
+
+      expect(eventName).to.equal('component-retrieved');
+      expect(eventData.headers).to.eql({});
+      expect(eventData.name).to.equal('async-error2-component');
+      expect(eventData.parameters).to.eql({});
+      expect(eventData.requestVersion).to.equal('1.X.X');
+      expect(eventData.href).to.equal(
         'http://components.com/async-error2-component/1.X.X'
       );
-      expect(fireStub.args[0][1].version).to.equal('1.0.0');
-      expect(fireStub.args[0][1].renderMode).to.equal('rendered');
-      expect(fireStub.args[0][1].duration).to.be.above(0);
-      expect(fireStub.args[0][1].status).to.equal(200);
+      expect(eventData.version).to.equal('1.0.0');
+      expect(eventData.renderMode).to.equal('rendered');
+      expect(eventData.duration).to.be.above(0);
+      expect(eventData.status).to.equal(200);
     });
   });
 
@@ -157,19 +159,33 @@ describe('registry : routes : helpers : get-component', () => {
       );
     });
 
+    it('should fire a data-provider-error event', () => {
+      const [eventName, eventData] = fireStub.args[0];
+
+      expect(eventName).to.equal('data-provider-error');
+      expect(eventData.name).to.equal('async-error2-component');
+      expect(eventData.parameters).to.eql({ error: true });
+      expect(eventData.requestVersion).to.equal('1.X.X');
+      expect(eventData.version).to.equal('1.0.0');
+      expect(eventData.status).to.equal(500);
+      expect(eventData.error).to.be.an('error');
+    });
+
     it('should fire a component-retrieved event', () => {
-      expect(fireStub.args[0][0]).to.equal('component-retrieved');
-      expect(fireStub.args[0][1].headers).to.eql({});
-      expect(fireStub.args[0][1].name).to.equal('async-error2-component');
-      expect(fireStub.args[0][1].parameters).to.eql({ error: true });
-      expect(fireStub.args[0][1].requestVersion).to.equal('1.X.X');
-      expect(fireStub.args[0][1].href).to.equal(
+      const [eventName, eventData] = fireStub.args[1];
+
+      expect(eventName).to.equal('component-retrieved');
+      expect(eventData.headers).to.eql({});
+      expect(eventData.name).to.equal('async-error2-component');
+      expect(eventData.parameters).to.eql({ error: true });
+      expect(eventData.requestVersion).to.equal('1.X.X');
+      expect(eventData.href).to.equal(
         'http://components.com/async-error2-component/1.X.X?error=true'
       );
-      expect(fireStub.args[0][1].version).to.equal('1.0.0');
-      expect(fireStub.args[0][1].renderMode).to.equal('rendered');
-      expect(fireStub.args[0][1].duration).to.be.above(0);
-      expect(fireStub.args[0][1].status).to.equal(500);
+      expect(eventData.version).to.equal('1.0.0');
+      expect(eventData.renderMode).to.equal('rendered');
+      expect(eventData.duration).to.be.above(0);
+      expect(eventData.status).to.equal(500);
     });
   });
 


### PR DESCRIPTION
Sometimes it's useful being able to track when your components fail and how, specially when doing changes in the registry that might affect the components. Right now the only thing that can be tracked outside are the requests, but that only gets you the status, not the error.

This adds error events for failure on component data provider calls, so they can be retreived and sent to logs.