### PR TITLE
fix not adding oc-client on dev mode multiple times

### DIFF
--- a/src/registry/domain/repository.ts
+++ b/src/registry/domain/repository.ts
@@ -76,7 +76,9 @@ export default function repository(conf: Config) {
           return isValidComponent;
         });
 
-      validComponents.push('oc-client');
+      if (!validComponents.includes('oc-client')) {
+        validComponents.push('oc-client');
+      }
       return validComponents;
     },
     getComponentVersions(componentName: string): Promise<string[]> {
@@ -356,9 +358,8 @@ export default function repository(conf: Config) {
         };
       }
 
-      const componentVersions = await repository.getComponentVersions(
-        componentName
-      );
+      const componentVersions =
+        await repository.getComponentVersions(componentName);
 
       if (
         !versionHandler.validateNewVersion(componentVersion, componentVersions)

--- a/src/registry/domain/repository.ts
+++ b/src/registry/domain/repository.ts
@@ -76,10 +76,7 @@ export default function repository(conf: Config) {
           return isValidComponent;
         });
 
-      if (!validComponents.includes('oc-client')) {
-        validComponents.push('oc-client');
-      }
-      return validComponents;
+      return [...validComponents, 'oc-client'];
     },
     getComponentVersions(componentName: string): Promise<string[]> {
       if (componentName === 'oc-client') {


### PR DESCRIPTION
When a components list is passed, the array was mutated every time by adding oc-client, which resulted in the component appearing multiple times.