### PR TITLE
Add a compileClient option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc",
-  "version": "0.49.40",
+  "version": "0.49.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc",
-      "version": "0.49.40",
+      "version": "0.49.41",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
@@ -31,7 +31,7 @@
         "multer": "^1.4.3",
         "nice-cache": "^0.0.5",
         "oc-client": "^4.0.1",
-        "oc-client-browser": "^1.7.3",
+        "oc-client-browser": "^1.7.4",
         "oc-empty-response-handler": "^1.0.2",
         "oc-get-unix-utc-timestamp": "^1.0.6",
         "oc-s3-storage-adapter": "^2.1.1",
@@ -7624,9 +7624,9 @@
       }
     },
     "node_modules/oc-client-browser": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.7.3.tgz",
-      "integrity": "sha512-o688FTKJgP2YqwloAJJSAGkvLpRLU0XFcXQmlJupWGQS+ME9FqymjJVd9uAnqI1ypYEARz97dwM4ZUs7MEJqOA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.7.4.tgz",
+      "integrity": "sha512-0SzviP+b+4pv6USZqtX68rLJO7xODBfF+R+McSqZvAaSA0CZznXleHahRq62fjdNT68v4M5mwqwOJb2bzfhZ6A==",
       "dependencies": {
         "uglify-js": "3.14.2",
         "universalify": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",
     "oc-client": "^4.0.1",
-    "oc-client-browser": "^1.7.3",
+    "oc-client-browser": "^1.7.4",
     "oc-empty-response-handler": "^1.0.2",
     "oc-get-unix-utc-timestamp": "^1.0.6",
     "oc-s3-storage-adapter": "^2.1.1",

--- a/src/registry/domain/options-sanitiser.ts
+++ b/src/registry/domain/options-sanitiser.ts
@@ -7,7 +7,7 @@ const DEFAULT_NODE_KEEPALIVE_MS = 5000;
 
 export interface Input extends Partial<Omit<Config, 'beforePublish'>> {
   baseUrl: string;
-  customClient?: boolean;
+  compileClient?: boolean;
 }
 
 export default function optionsSanitiser(input: Input): Config {
@@ -58,7 +58,7 @@ export default function optionsSanitiser(input: Input): Config {
     options.templates = [];
   }
 
-  if (options.customClient) {
+  if (options.compileClient) {
     options.compiledClient = compileSync({ templates: options.templates });
   }
 

--- a/src/registry/domain/options-sanitiser.ts
+++ b/src/registry/domain/options-sanitiser.ts
@@ -9,9 +9,6 @@ export interface Input extends Partial<Omit<Config, 'beforePublish'>> {
   baseUrl: string;
   customClient?: boolean;
 }
-type RegisteredTemplate = {
-  externals: Array<{ global: string | string[]; url: string; name: string }>;
-};
 
 export default function optionsSanitiser(input: Input): Config {
   const options = { ...input };
@@ -62,12 +59,7 @@ export default function optionsSanitiser(input: Input): Config {
   }
 
   if (options.customClient) {
-    const templates: Record<string, RegisteredTemplate> = {};
-    for (const template of options.templates) {
-      const { externals, type } = template.getInfo();
-      templates[type] = { externals };
-    }
-    options.compiledClient = compileSync({ templates });
+    options.compiledClient = compileSync({ templates: options.templates });
   }
 
   if (!options.dependencies) {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -9,13 +9,9 @@ import * as middleware from './middleware';
 import * as pluginsInitialiser from './domain/plugins-initialiser';
 import Repository from './domain/repository';
 import { create as createRouter } from './router';
-import sanitiseOptions from './domain/options-sanitiser';
+import sanitiseOptions, { Input } from './domain/options-sanitiser';
 import * as validator from './domain/validators';
-import { Config, Plugin } from '../types';
-
-interface Input extends Partial<Omit<Config, 'beforePublish'>> {
-  baseUrl: string;
-}
+import { Plugin } from '../types';
 
 export default function registry(inputOptions: Input) {
   const validationResult =

--- a/src/registry/routes/static-redirector.ts
+++ b/src/registry/routes/static-redirector.ts
@@ -7,7 +7,7 @@ import type { Repository } from '../domain/repository';
 
 export default function staticRedirector(repository: Repository) {
   return function (req: Request, res: Response): void {
-    let filePath = '';
+    let filePath;
     const clientPath = `${res.conf.prefix || '/'}oc-client/client.js`;
     const clientMapPath = `${
       res.conf.prefix || '/'

--- a/src/registry/routes/static-redirector.ts
+++ b/src/registry/routes/static-redirector.ts
@@ -7,7 +7,7 @@ import type { Repository } from '../domain/repository';
 
 export default function staticRedirector(repository: Repository) {
   return function (req: Request, res: Response): void {
-    let filePath;
+    let filePath = '';
     const clientPath = `${res.conf.prefix || '/'}oc-client/client.js`;
     const clientMapPath = `${
       res.conf.prefix || '/'
@@ -20,6 +20,11 @@ export default function staticRedirector(repository: Repository) {
           '../../components/oc-client/_package/src/oc-client.js'
         );
       } else {
+        if (res.conf.compiledClient) {
+          res.type('application/javascript');
+          res.send(res.conf.compiledClient.code);
+          return;
+        }
         return res.redirect(repository.getStaticClientPath());
       }
     } else if (req.route.path === clientMapPath) {
@@ -29,6 +34,11 @@ export default function staticRedirector(repository: Repository) {
           '../../components/oc-client/_package/src/oc-client.min.map'
         );
       } else {
+        if (res.conf.compiledClient) {
+          res.type('text/plain');
+          res.send(res.conf.compiledClient.map);
+          return;
+        }
         return res.redirect(repository.getStaticClientMapPath());
       }
     } else if (req.params['componentName'] === 'oc-client') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export type PublishAuthConfig =
 
 export interface Config {
   baseUrl: string;
+  compiledClient?: { code: string; map: string };
   baseUrlFunc?: (opts: { host?: string; secure: boolean }) => string;
   beforePublish: (req: Request, res: Response, next: NextFunction) => void;
   customHeadersToSkipOnWeakVersion: string[];
@@ -189,7 +190,7 @@ export interface Config {
     options: Record<string, any> & { componentsDir: string };
   };
   tempDir: string;
-  templates: any[];
+  templates: Template[];
   timeout: number;
   verbosity: number;
 }


### PR DESCRIPTION
This adds a new option for the registry config

`compileClient?: boolean`

The idea behind is that, if set to true, the oc-client will be compiled and served from the registry, and it will include all the templates registered on the registry (the ones you add on the `templates` option of your config). So when calling your-registry/oc-client/client.js, you will get a client with the templates your registry has registered. It has the penalty of not being accessed through CDN, but you can put one in front of the endpoint if you wanted