### PR TITLE
always compile client on dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc",
-  "version": "0.49.41",
+  "version": "0.49.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc",
-      "version": "0.49.41",
+      "version": "0.49.42",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
@@ -31,7 +31,7 @@
         "multer": "^1.4.3",
         "nice-cache": "^0.0.5",
         "oc-client": "^4.0.1",
-        "oc-client-browser": "^1.7.4",
+        "oc-client-browser": "^1.7.5",
         "oc-empty-response-handler": "^1.0.2",
         "oc-get-unix-utc-timestamp": "^1.0.6",
         "oc-s3-storage-adapter": "^2.1.1",
@@ -7624,9 +7624,9 @@
       }
     },
     "node_modules/oc-client-browser": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.7.4.tgz",
-      "integrity": "sha512-0SzviP+b+4pv6USZqtX68rLJO7xODBfF+R+McSqZvAaSA0CZznXleHahRq62fjdNT68v4M5mwqwOJb2bzfhZ6A==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.7.5.tgz",
+      "integrity": "sha512-A58HpjAqHYOj8k/W6+5wTtZOTXEjUGJbcc3Wk9Xvp7CQKJpEzMNTQmHEkHEQK9JMQI+nPujeKqMiJ0e3BeaDqA==",
       "dependencies": {
         "uglify-js": "3.14.2",
         "universalify": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",
     "oc-client": "^4.0.1",
-    "oc-client-browser": "^1.7.4",
+    "oc-client-browser": "^1.7.5",
     "oc-empty-response-handler": "^1.0.2",
     "oc-get-unix-utc-timestamp": "^1.0.6",
     "oc-s3-storage-adapter": "^2.1.1",

--- a/src/cli/facade/dev.ts
+++ b/src/cli/facade/dev.ts
@@ -169,6 +169,7 @@ const dev = ({ local, logger }: { logger: Logger; local: Local }) =>
         baseUrl,
         prefix: opts.prefix || '',
         dependencies: dependencies.modules,
+        compileClient: true,
         discovery: true,
         env: { name: 'local' },
         fallbackRegistryUrl,

--- a/src/registry/routes/static-redirector.ts
+++ b/src/registry/routes/static-redirector.ts
@@ -15,10 +15,16 @@ export default function staticRedirector(repository: Repository) {
 
     if (req.route.path === clientPath) {
       if (res.conf.local) {
-        filePath = path.join(
-          __dirname,
-          '../../components/oc-client/_package/src/oc-client.js'
-        );
+        if (res.conf.compiledClient) {
+          res.type('application/javascript');
+          res.send(res.conf.compiledClient.dev);
+          return;
+        } else {
+          filePath = path.join(
+            __dirname,
+            '../../components/oc-client/_package/src/oc-client.js'
+          );
+        }
       } else {
         if (res.conf.compiledClient) {
           res.type('application/javascript');

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,7 @@ export type PublishAuthConfig =
 
 export interface Config {
   baseUrl: string;
-  compiledClient?: { code: string; map: string };
+  compiledClient?: { code: string; map: string; dev: string };
   baseUrlFunc?: (opts: { host?: string; secure: boolean }) => string;
   beforePublish: (req: Request, res: Response, next: NextFunction) => void;
   customHeadersToSkipOnWeakVersion: string[];


### PR DESCRIPTION
Always compile client when running oc dev. This helps so if you want to inject your local registry in a website to see how it looks, all templates you use in your local registry will be included in the client.js served.