### PR TITLE
infer storage type and export config type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { default as cli } from './cli/programmatic-api';
 export { default as Client } from 'oc-client';
-export { default as Registry } from './registry';
+export { default as Registry, RegistryOptions } from './registry';

--- a/src/registry/domain/options-sanitiser.ts
+++ b/src/registry/domain/options-sanitiser.ts
@@ -5,12 +5,13 @@ import * as auth from './authentication';
 
 const DEFAULT_NODE_KEEPALIVE_MS = 5000;
 
-export interface Input extends Partial<Omit<Config, 'beforePublish'>> {
+export interface RegistryOptions<T = any>
+  extends Partial<Omit<Config<T>, 'beforePublish'>> {
   baseUrl: string;
   compileClient?: boolean | { retryLimit?: number; retryInterval?: number };
 }
 
-export default function optionsSanitiser(input: Input): Config {
+export default function optionsSanitiser(input: RegistryOptions): Config {
   const options = { ...input };
 
   if (!options.publishAuth) {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -9,11 +9,13 @@ import * as middleware from './middleware';
 import * as pluginsInitialiser from './domain/plugins-initialiser';
 import Repository from './domain/repository';
 import { create as createRouter } from './router';
-import sanitiseOptions, { Input } from './domain/options-sanitiser';
+import sanitiseOptions, { RegistryOptions } from './domain/options-sanitiser';
 import * as validator from './domain/validators';
 import { Plugin } from '../types';
 
-export default function registry(inputOptions: Input) {
+export { RegistryOptions };
+
+export default function registry<T = any>(inputOptions: RegistryOptions<T>) {
   const validationResult =
     validator.validateRegistryConfiguration(inputOptions);
   if (!validationResult.isValid) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ export type PublishAuthConfig =
     }
   | ({ type: string | Authentication } & Record<string, any>);
 
-export interface Config {
+export interface Config<T = any> {
   baseUrl: string;
   compiledClient?: { code: string; map: string; dev: string };
   baseUrlFunc?: (opts: { host?: string; secure: boolean }) => string;
@@ -186,8 +186,8 @@ export interface Config {
     componentsDir: string;
   };
   storage: {
-    adapter: (options: any) => StorageAdapter;
-    options: Record<string, any> & { componentsDir: string };
+    adapter: (options: T) => StorageAdapter;
+    options: T & { componentsDir: string };
   };
   tempDir: string;
   templates: Template[];


### PR DESCRIPTION
Export type with inferred generic for the Registry options so when you configure the registry the options are inferred

<img width="291" alt="image" src="https://github.com/opencomponents/oc/assets/16902309/ee9c3fcd-dfc9-4734-b9ac-37918070954e">