### PR TITLE
ban eval from ocs

### DIFF
--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -551,6 +551,7 @@ export default function getComponent(conf: Config, repository: Repository) {
                     console: conf.local ? console : noopConsole,
                     setTimeout,
                     Buffer,
+                    eval: undefined,
                     fetch: globalThis?.fetch
                   };
 


### PR DESCRIPTION
There was a security exploit where components could use `eval` to escape their context and execute code on the registry. This is because by default, code in VM will have access to eval even if it's not explicitly passed. This explicitly sets it as undefined so is not possible to do it anymore.