### PR TITLE
move to p-limit await import. node 18 and improve plugin type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc",
-  "version": "0.49.44",
+  "version": "0.49.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc",
-      "version": "0.49.44",
+      "version": "0.49.46",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
@@ -90,7 +90,7 @@
         "minimist": "^1.2.8",
         "mocha": "^9.1.3",
         "node-emoji": "^1.11.0",
-        "p-limit": "^3.1.0",
+        "p-limit": "^5.0.0",
         "prettier": "^3.2.4",
         "rimraf": "^3.0.2",
         "semver-sort": "^1.0.0",
@@ -8298,6 +8298,36 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -8312,14 +8342,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -10226,12 +10253,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "husky install"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "repository": {
     "type": "git",
@@ -71,7 +71,7 @@
     "minimist": "^1.2.8",
     "mocha": "^9.1.3",
     "node-emoji": "^1.11.0",
-    "p-limit": "^3.1.0",
+    "p-limit": "^5.0.0",
     "prettier": "^3.2.4",
     "rimraf": "^3.0.2",
     "semver-sort": "^1.0.0",

--- a/src/registry/domain/components-cache/components-list.ts
+++ b/src/registry/domain/components-cache/components-list.ts
@@ -1,5 +1,4 @@
 import semver from 'semver';
-import pLimit from 'p-limit';
 import getUnixUTCTimestamp from 'oc-get-unix-utc-timestamp';
 import { StorageAdapter } from 'oc-storage-adapters-utils';
 import eventsHandler from '../events-handler';
@@ -40,6 +39,7 @@ export default function componentsList(conf: Config, cdn: StorageAdapter) {
         const unCheckedVersions = allVersions.filter(
           version => !jsonList?.components[componentName]?.includes(version)
         );
+        const { default: pLimit } = await import('p-limit');
         const limit = pLimit(cdn.maxConcurrentRequests);
         const invalidVersions = (
           await Promise.all(
@@ -76,6 +76,7 @@ export default function componentsList(conf: Config, cdn: StorageAdapter) {
         const components = await cdn.listSubDirectories(
           conf.storage.options.componentsDir
         );
+        const { default: pLimit } = await import('p-limit');
         const limit = pLimit(cdn.maxConcurrentRequests);
 
         const versions = await Promise.all(

--- a/src/registry/domain/components-details.ts
+++ b/src/registry/domain/components-details.ts
@@ -1,4 +1,3 @@
-import pLimit from 'p-limit';
 import _ from 'lodash';
 import eventsHandler from './events-handler';
 import getUnixUTCTimestamp from 'oc-get-unix-utc-timestamp';
@@ -42,6 +41,7 @@ export default function componentsDetails(conf: Config, cdn: StorageAdapter) {
       });
     });
 
+    const { default: pLimit } = await import('p-limit');
     const limit = pLimit(cdn.maxConcurrentRequests);
 
     await Promise.all(

--- a/src/registry/domain/plugins-initialiser.ts
+++ b/src/registry/domain/plugins-initialiser.ts
@@ -1,4 +1,3 @@
-import pLimit from 'p-limit';
 import _ from 'lodash';
 import { DepGraph } from 'dependency-graph';
 import { promisify } from 'util';
@@ -117,6 +116,7 @@ export async function init(
     return registered;
   };
 
+  const { default: pLimit } = await import('p-limit');
   const onSeries = pLimit(1);
 
   await Promise.all(

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -35,8 +35,8 @@ export default function registry<T = any>(inputOptions: RegistryOptions<T>) {
     return callback('not opened');
   };
 
-  const register = (
-    plugin: Omit<Plugin, 'callback'>,
+  const register = <T = any>(
+    plugin: Omit<Plugin<T>, 'callback'>,
     callback?: (...args: any[]) => void
   ) => {
     plugins.push(Object.assign(plugin, { callback }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,14 +224,14 @@ export interface Template {
   ) => void;
 }
 
-export interface Plugin {
+export interface Plugin<T = any> {
   callback?: (error: unknown) => void;
   description?: string;
   name: string;
-  options?: any;
+  options?: T;
   register: {
     register: (
-      options: any,
+      options: T,
       dependencies: any,
       next: (error?: Error) => void
     ) => void;


### PR DESCRIPTION
This makes the minimum node version 18, updates p-limit and uses `await import` syntax since its ESM only and OC still relies on CJS and improves type inference of options when registering plugins.