### PR TITLE
add postRequestPayloadSize on dev and fix type

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -33,6 +33,10 @@ export default {
             'Enable hot reloading. Note: when hot reloading is set to true, each request to the component will make the registry to create a new instance for the javascript closures to be loaded, while when false the instance will be recycled between components executions',
           default: true
         },
+        postRequestPayloadSize: {
+          description: 'Maximum payload size for post requests',
+          default: '100kb'
+        },
         verbose: {
           boolean: true,
           description: 'Verbosity',

--- a/src/cli/facade/dev.ts
+++ b/src/cli/facade/dev.ts
@@ -30,6 +30,7 @@ const dev = ({ local, logger }: { logger: Logger; local: Local }) =>
       baseUrl: string;
       fallbackRegistryUrl: string;
       hotReloading?: boolean;
+      postRequestPayloadSize?: string;
       components?: string[];
       watch?: boolean;
       verbose?: boolean;
@@ -43,6 +44,7 @@ const dev = ({ local, logger }: { logger: Logger; local: Local }) =>
         typeof opts.hotReloading === 'undefined' ? true : opts.hotReloading;
       const optWatch = typeof opts.watch === 'undefined' ? true : opts.watch;
       let packaging = false;
+      const postRequestPayloadSize = opts.postRequestPayloadSize || '100kb';
 
       const watchForChanges = function (
         {
@@ -176,6 +178,7 @@ const dev = ({ local, logger }: { logger: Logger; local: Local }) =>
         hotReloading,
         liveReloadPort: liveReload.port,
         local: true,
+        postRequestPayloadSize,
         components: opts.components,
         path: path.resolve(componentsDir),
         port,

--- a/src/registry/middleware/index.ts
+++ b/src/registry/middleware/index.ts
@@ -29,8 +29,10 @@ export const bind = (app: Express, options: Config): Express => {
   app.use(requestHandler());
 
   if (options.postRequestPayloadSize) {
-    bodyParserJsonArgument.limit = options.postRequestPayloadSize;
-    bodyParserUrlEncodedArgument.limit = options.postRequestPayloadSize;
+    // Type is incorrect since limit can be a string like '50mb'
+    bodyParserJsonArgument.limit = options.postRequestPayloadSize as number;
+    bodyParserUrlEncodedArgument.limit =
+      options.postRequestPayloadSize as number;
   }
 
   app.use(express.json(bodyParserJsonArgument));

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,7 +163,7 @@ export interface Config<T = any> {
   plugins: Record<string, (...args: unknown[]) => void>;
   pollingInterval: number;
   port: number | string;
-  postRequestPayloadSize?: number;
+  postRequestPayloadSize?: string | number;
   prefix: string;
   publishAuth?: PublishAuthConfig;
   publishValidation: (data: unknown) =>


### PR DESCRIPTION
Add an option for `oc dev` to set the postRequestPayloadSize so you can simulate on local the same max you have on your registry, and fix the type since it can be either a number or string.