### PR TITLE
calculate sizes on packaging and show in registry UI if available

### DIFF
--- a/src/registry/domain/components-details.ts
+++ b/src/registry/domain/components-details.ts
@@ -52,7 +52,8 @@ export default function componentsDetails(conf: Config, cdn: StorageAdapter) {
             true
           );
           details.components[name][version] = {
-            publishDate: content.oc.date || 0
+            publishDate: content.oc.date || 0,
+            templateSize: content.oc.files.template.size
           };
         })
       )

--- a/src/registry/routes/helpers/get-components-history.ts
+++ b/src/registry/routes/helpers/get-components-history.ts
@@ -5,12 +5,14 @@ interface UnformmatedComponentHistory {
   name: string;
   version: string;
   publishDate: number;
+  templateSize?: number;
 }
 
 interface ComponentHistory {
   name: string;
   version: string;
   publishDate: string;
+  templateSize?: number;
 }
 
 export default function getComponentsHistory(
@@ -23,6 +25,7 @@ export default function getComponentsHistory(
       result.push({
         name,
         publishDate: details.publishDate,
+        templateSize: details.templateSize,
         version
       });
     }
@@ -33,6 +36,7 @@ export default function getComponentsHistory(
     .map(x => ({
       name: x.name,
       version: x.version,
+      templateSize: x.templateSize,
       publishDate: !x.publishDate
         ? 'Unknown'
         : dateStringified(new Date(x.publishDate))

--- a/src/registry/views/info.ts
+++ b/src/registry/views/info.ts
@@ -61,6 +61,7 @@ export default function info(vm: Vm): string {
     ${property('Template', template)}
     ${showArray('Node.js dependencies', dependencies)}
     ${showArray('Plugin dependencies', component.oc.plugins)}
+    ${component.oc.files.template.size ? property('Template size', `${Math.round(component.oc.files.template.size / 1024)} kb`) : ''}
     ${componentParameters()}
     <h3>Code</h3>
     <p>

--- a/src/registry/views/info.ts
+++ b/src/registry/views/info.ts
@@ -27,7 +27,6 @@ function statsJs(componentDetail: ComponentDetail) {
   <script>
   (function () {
     const componentDetail = ${JSON.stringify(componentDetail)};
-    window.componentDetail = componentDetail;
     const ctx = document.getElementById('stats');
     const dataPoints = [];
     const versionNumbers = Object.keys(componentDetail);

--- a/src/registry/views/info.ts
+++ b/src/registry/views/info.ts
@@ -1,4 +1,4 @@
-import { Component } from '../../types';
+import { Component, ComponentDetail } from '../../types';
 
 import getComponentAuthor from './partials/component-author';
 import getComponentParameters from './partials/component-parameters';
@@ -12,11 +12,87 @@ import isTemplateLegacy from '../../utils/is-template-legacy';
 interface Vm {
   parsedAuthor: { name?: string; email?: string; url?: string };
   component: Component;
+  componentDetail?: ComponentDetail;
   dependencies: string[];
   href: string;
   sandBoxDefaultQs: string;
   title: string;
   repositoryUrl: string | null;
+}
+
+function statsJs(componentDetail: ComponentDetail) {
+  return `
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+  <script>
+  (function () {
+    const componentDetail = ${JSON.stringify(componentDetail)};
+    window.componentDetail = componentDetail;
+    const ctx = document.getElementById('stats');
+    const dataPoints = [];
+    const versionNumbers = Object.keys(componentDetail);
+  
+    for (const versionNumber of versionNumbers) {
+      const versionData = componentDetail[versionNumber];
+      const date = new Date(versionData.publishDate);
+      const size = Math.round(versionData.templateSize / 1024);
+  
+      // Add the data point to the array
+      dataPoints.push({ x: date, y: size, version: versionNumber });
+    }
+  
+    const dataset = {
+      label: 'guest-stay-config',
+      data: dataPoints,
+      tension: 0.1,
+      borderWidth: 1
+    }
+  
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        datasets: [dataset]
+      },
+      options: {
+        plugins: {
+          tooltip: {
+            callbacks: {
+              footer(items) {
+                const version = items[0].raw.version;
+                return 'Version: ' + version;
+              }
+            }
+          }
+        },
+        title: {
+          display: true,
+          text: "Package Sizes Over Time",
+        },
+        scales: {
+          x: {
+            type: "time",
+            time: {
+              unit: "day",
+            },
+            display: true,
+            title: {
+              display: true,
+              text: 'Date published'
+            }
+          },
+          y: {
+            display: true,
+            title: {
+              display: true,
+              text: 'Size in KB'
+            }
+          },
+        },
+      }
+    });
+    }());
+  </script>
+  `;
 }
 
 export default function info(vm: Vm): string {
@@ -49,10 +125,18 @@ export default function info(vm: Vm): string {
       ? 'legacy'
       : compiler + '@' + component.oc.files.template.version
   })`;
+  const statsAvailable =
+    !!vm.componentDetail && Object.keys(vm.componentDetail).length > 1;
 
   const content = `<a class="back" href="${href}">&lt;&lt; All components</a>
     <h2>${component.name} &nbsp;${componentVersions()}</h2>
     <p class="w-100">${component.description} ${componentState()}</p>
+    ${
+      statsAvailable
+        ? `<h3>Stats</h3>
+           <canvas id="stats" width="400" height="200"></canvas>`
+        : ''
+    }
     <h3>Component Info</h3>
     ${property('Repository', repositoryUrl || 'not available', !!repositoryUrl)}
     ${componentAuthor()}
@@ -82,9 +166,12 @@ export default function info(vm: Vm): string {
     </h3>
     <iframe class="preview" src="~preview/${sandBoxDefaultQs}"></iframe>`;
 
-  const scripts = `<script>var thisComponentHref="${href}${component.name}/";
+  const scripts = `
+  <script>var thisComponentHref="${href}${component.name}/";
     ${infoJS}
-  </script>`;
+  </script>
+  ${statsAvailable ? statsJs(vm.componentDetail!) : ''}
+  `;
 
   return layout({ content, scripts });
 }

--- a/src/registry/views/partials/components-history.ts
+++ b/src/registry/views/partials/components-history.ts
@@ -4,17 +4,20 @@ export default function componentsHistory(vm: VM): string {
   const componentRow = ({
     name,
     publishDate,
-    version
+    version,
+    templateSize
   }: {
     name: string;
+    templateSize?: number;
     publishDate: string;
     version: string;
-  }) =>
-    `<a href="${name}/${version}/~info">
+  }) => {
+    return `<a href="${name}/${version}/~info">
   <div class="componentRow row table">
-    <p class="release">${publishDate} - Published ${name}@${version}</p>
+    <p class="release">${publishDate} - Published ${name}@${version}${templateSize ? ` [${Math.round(templateSize / 1024)} kb]` : ''}</p>
   </div>
 </a>`;
+  };
 
   const history = vm.componentsHistory || [];
 

--- a/src/registry/views/partials/components-list.ts
+++ b/src/registry/views/partials/components-list.ts
@@ -3,11 +3,16 @@ import getSelectedCheckbox from './selected-checkbox';
 
 export default function componentsList(vm: VM): string {
   const isLocal = vm.type !== 'oc-registry';
+  const isRemote = !isLocal;
+  const sizeAvailable = vm.components.some(
+    component => component.oc.files.template.size
+  );
   const selectedCheckbox = getSelectedCheckbox(vm);
 
-  const extraColumn = !isLocal
+  const remoteServerColumns = isRemote
     ? '<div class="date">Updated</div><div class="activity">Activity</div>'
     : '';
+  const sizeColumn = sizeAvailable ? '<div>Size</div>' : '';
 
   const componentRow = (component: ParsedComponent) => {
     const componentState = component.oc.state
@@ -20,16 +25,21 @@ export default function componentsList(vm: VM): string {
       component.oc.state === 'deprecated' ||
       component.oc.state === 'experimental';
 
-    const extraColumn = !isLocal
+    const remoteServerColumns = isRemote
       ? `<div class="date">${
           component.oc.stringifiedDate || ''
         }</div><div class="activity">${component.allVersions.length}</div>`
       : '';
+    const sizeColumn = sizeAvailable
+      ? component.oc.files.template.size
+        ? `<div>${Math.round(component.oc.files.template.size / 1024)} kb</div>`
+        : '<div>? Kb</div>'
+      : '';
 
     return `<a href="${component.name}/${component.version}/~info">
   <div id="component-${component.name}" class="componentRow row table${
-      isHidden ? ' hide' : ''
-    }">
+    isHidden ? ' hide' : ''
+  }">
     <div class="title">
       <p class="name">${component.name}</p>
       <span class="description">${component.description}</span>
@@ -37,7 +47,8 @@ export default function componentsList(vm: VM): string {
     ${componentState}
     <div class="author">${component.author.name || ''}</div>
     <div>${component.version}</div>
-    ${extraColumn}
+    ${remoteServerColumns}
+    ${sizeColumn}
   </div>
 </a>`;
   };
@@ -58,7 +69,8 @@ export default function componentsList(vm: VM): string {
     <div class="title"></div>
     <div class="author">Author</div>
     <div>Latest version</div>
-    ${extraColumn}
+    ${remoteServerColumns}
+    ${sizeColumn}
   </div>
   ${vm.components.map(componentRow).join('')}
 </div>`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,14 +32,16 @@ export interface TemplateInfo {
   version: string;
 }
 
+export type ComponentDetail = {
+  [componentVersion: string]: {
+    publishDate: number;
+    templateSize?: number;
+  };
+};
+
 export interface ComponentsDetails {
   components: {
-    [componentName: string]: {
-      [componentVersion: string]: {
-        publishDate: number;
-        templateSize?: number;
-      };
-    };
+    [componentName: string]: ComponentDetail;
   };
   lastEdit: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ interface OcConfiguration {
       hashKey: string;
       src: string;
       type: string;
+      size?: number;
     };
     static: string[];
     template: {
@@ -78,6 +79,7 @@ interface OcConfiguration {
       src: string;
       type: string;
       version: string;
+      size?: number;
     };
     env?: string;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ interface ComponentHistory {
   name: string;
   publishDate: string;
   version: string;
+  templateSize: number;
 }
 
 export interface TemplateInfo {
@@ -34,7 +35,10 @@ export interface TemplateInfo {
 export interface ComponentsDetails {
   components: {
     [componentName: string]: {
-      [componentVersion: string]: { publishDate: number };
+      [componentVersion: string]: {
+        publishDate: number;
+        templateSize?: number;
+      };
     };
   };
   lastEdit: number;

--- a/test/unit/cli-domain-package-components.js
+++ b/test/unit/cli-domain-package-components.js
@@ -23,7 +23,10 @@ describe('cli : domain : package-components', () => {
     const fsMock = {
       existsSync: sinon.stub(),
       emptyDir: sinon.stub().resolves(),
-      readJson: sinon.stub()
+      readJson: sinon.stub(),
+      readdirSync: sinon.stub().returns(['template.js']),
+      statSync: sinon.stub().returns({ size: 300 }),
+      writeJsonSync: sinon.stub().returns({})
     };
 
     fsMock.existsSync.returns(true);
@@ -38,7 +41,8 @@ describe('cli : domain : package-components', () => {
       return {
         compile: function (options, callback) {
           if (options.componentPath === '.') {
-            callback(null, 'ok');
+            callback(null, { oc: { files: { template: {} } } });
+            // callback(null, 'ok');
           }
           if (options.componentPath === '') {
             callback(new Error('Ouch'));
@@ -63,15 +67,19 @@ describe('cli : domain : package-components', () => {
   describe('when packaging', () => {
     describe('when component is valid', () => {
       const PackageComponents = initialise();
-      it('should correctly invoke the callback when template succeed packaging', done => {
+      it.only('should add sizes and correctly invoke the callback when template succeed packaging', done => {
         let info;
         PackageComponents()({
           componentPath: '.',
           minify: true
         })
-          .then(res => (info = res))
+          .then(res => {
+            info = res;
+          })
           .finally(() => {
-            expect(info).to.equal('ok');
+            expect(info).to.deep.equal({
+              oc: { files: { template: { size: 300 } } }
+            });
             done();
           });
       });

--- a/test/unit/cli-domain-package-components.js
+++ b/test/unit/cli-domain-package-components.js
@@ -67,7 +67,7 @@ describe('cli : domain : package-components', () => {
   describe('when packaging', () => {
     describe('when component is valid', () => {
       const PackageComponents = initialise();
-      it.only('should add sizes and correctly invoke the callback when template succeed packaging', done => {
+      it('should add sizes and correctly invoke the callback when template succeed packaging', done => {
         let info;
         PackageComponents()({
           componentPath: '.',

--- a/test/unit/registry-domain-components-details.js
+++ b/test/unit/registry-domain-components-details.js
@@ -165,7 +165,7 @@ describe('registry : domain : components-details', () => {
                 components: {
                   hello: {
                     '1.0.0': { publishDate: 1459864868000 },
-                    '1.0.1': { publishDate: 1459864868001 }
+                    '1.0.1': { publishDate: 1459864868001, templateSize: 300 }
                   }
                 }
               })
@@ -236,7 +236,7 @@ describe('registry : domain : components-details', () => {
                 components: {
                   hello: {
                     '1.0.0': { publishDate: 1459864868000 },
-                    '1.0.1': { publishDate: 1459864868001 }
+                    '1.0.1': { publishDate: 1459864868001, templateSize: 300 }
                   }
                 }
               });
@@ -380,8 +380,8 @@ describe('registry : domain : components-details', () => {
               lastEdit: 1234567890,
               components: {
                 hello: {
-                  '1.0.0': { publishDate: 1459864868000 },
-                  '1.0.1': { publishDate: 1459864868001 }
+                  '1.0.0': { publishDate: 1459864868000, templateSize: 300 },
+                  '1.0.1': { publishDate: 1459864868001, templateSize: 300 }
                 }
               }
             })
@@ -454,8 +454,8 @@ describe('registry : domain : components-details', () => {
               lastEdit: 1234567890,
               components: {
                 hello: {
-                  '1.0.0': { publishDate: 1459864868000 },
-                  '1.0.1': { publishDate: 1459864868001 }
+                  '1.0.0': { publishDate: 1459864868000, templateSize: 300 },
+                  '1.0.1': { publishDate: 1459864868001, templateSize: 300 }
                 }
               }
             });

--- a/test/unit/registry-domain-components-details.js
+++ b/test/unit/registry-domain-components-details.js
@@ -103,7 +103,9 @@ describe('registry : domain : components-details', () => {
         before(done => {
           stubs = { getJson: sinon.stub() };
           stubs.getJson.onCall(0).resolves(details);
-          stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868001 } });
+          stubs.getJson.onCall(1).resolves({
+            oc: { date: 1459864868001, files: { template: { size: 300 } } }
+          });
           stubs.maxConcurrentRequests = 20;
           stubs.putFileContent = sinon.stub().resolves('ok');
           const componentsDetails = ComponentsDetails(conf, stubs);
@@ -144,7 +146,9 @@ describe('registry : domain : components-details', () => {
           before(done => {
             stubs = { getJson: sinon.stub() };
             stubs.getJson.onCall(0).resolves(details);
-            stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868001 } });
+            stubs.getJson.onCall(1).resolves({
+              oc: { date: 1459864868001, files: { template: { size: 300 } } }
+            });
             stubs.maxConcurrentRequests = 20;
             stubs.putFileContent = sinon.stub().resolves('ok');
             const componentsDetails = ComponentsDetails(conf, stubs);
@@ -173,7 +177,12 @@ describe('registry : domain : components-details', () => {
               fireStub.reset();
               stubs = { getJson: sinon.stub() };
               stubs.getJson.onCall(0).resolves(details);
-              stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868001 } });
+              stubs.getJson.onCall(1).resolves({
+                oc: {
+                  date: 1459864868001,
+                  files: { template: { size: 300 } }
+                }
+              });
               stubs.maxConcurrentRequests = 20;
               stubs.putFileContent = sinon
                 .stub()
@@ -208,7 +217,9 @@ describe('registry : domain : components-details', () => {
             before(done => {
               stubs = { getJson: sinon.stub() };
               stubs.getJson.onCall(0).resolves(details);
-              stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868001 } });
+              stubs.getJson.onCall(1).resolves({
+                oc: { date: 1459864868001, files: { template: { size: 300 } } }
+              });
               stubs.maxConcurrentRequests = 20;
               stubs.putFileContent = sinon.stub().resolves('ok');
               const componentsDetails = ComponentsDetails(conf, stubs);
@@ -298,8 +309,12 @@ describe('registry : domain : components-details', () => {
       before(done => {
         stubs = { getJson: sinon.stub() };
         stubs.getJson.onCall(0).resolves('not found');
-        stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868000 } });
-        stubs.getJson.onCall(2).resolves({ oc: { date: 1459864868001 } });
+        stubs.getJson.onCall(1).resolves({
+          oc: { date: 1459864868000, files: { template: { size: 300 } } }
+        });
+        stubs.getJson.onCall(2).resolves({
+          oc: { date: 1459864868001, files: { template: { size: 300 } } }
+        });
         stubs.maxConcurrentRequests = 20;
         stubs.putFileContent = sinon.stub().resolves('ok');
         const componentsDetails = ComponentsDetails(conf, stubs);
@@ -344,8 +359,12 @@ describe('registry : domain : components-details', () => {
         before(done => {
           stubs = { getJson: sinon.stub() };
           stubs.getJson.onCall(0).rejects('not found');
-          stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868000 } });
-          stubs.getJson.onCall(2).resolves({ oc: { date: 1459864868001 } });
+          stubs.getJson.onCall(1).resolves({
+            oc: { date: 1459864868000, files: { template: { size: 300 } } }
+          });
+          stubs.getJson.onCall(2).resolves({
+            oc: { date: 1459864868001, files: { template: { size: 300 } } }
+          });
           stubs.maxConcurrentRequests = 20;
           stubs.putFileContent = sinon.stub().resolves('ok');
           const componentsDetails = ComponentsDetails(conf, stubs);
@@ -374,8 +393,12 @@ describe('registry : domain : components-details', () => {
             fireStub.reset();
             stubs = { getJson: sinon.stub() };
             stubs.getJson.onCall(0).rejects('not found');
-            stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868000 } });
-            stubs.getJson.onCall(2).resolves({ oc: { date: 1459864868001 } });
+            stubs.getJson.onCall(1).resolves({
+              oc: { date: 1459864868000, files: { template: { size: 300 } } }
+            });
+            stubs.getJson.onCall(2).resolves({
+              oc: { date: 1459864868001, files: { template: { size: 300 } } }
+            });
             stubs.maxConcurrentRequests = 20;
             stubs.putFileContent = sinon
               .stub()
@@ -410,8 +433,12 @@ describe('registry : domain : components-details', () => {
           before(done => {
             stubs = { getJson: sinon.stub() };
             stubs.getJson.onCall(0).rejects('not found');
-            stubs.getJson.onCall(1).resolves({ oc: { date: 1459864868000 } });
-            stubs.getJson.onCall(2).resolves({ oc: { date: 1459864868001 } });
+            stubs.getJson.onCall(1).resolves({
+              oc: { date: 1459864868000, files: { template: { size: 300 } } }
+            });
+            stubs.getJson.onCall(2).resolves({
+              oc: { date: 1459864868001, files: { template: { size: 300 } } }
+            });
             stubs.maxConcurrentRequests = 20;
             stubs.putFileContent = sinon.stub().resolves('ok');
             const componentsDetails = ComponentsDetails(conf, stubs);


### PR DESCRIPTION
This adds two new fields in package.json when packaged by OC.

`oc.files.template.size: number`: size in bytes of the template (including all js files like react-component.js if using older templates).
`oc.files.dataProvider.size?: number`: size in bytes of the server.js (if exists).

Then, if at least there is one component in the component list with the size defined, a new column will appear called "Size" that will show the size in kbs of the template. On the info will also show on the properties.

For now I'm not showing the size of the server on the Registry UI as I'm not sure is as valuable, but I'm saving it on package.json just in case I want to add it in the future.