### PR TITLE
npm install after oc init

### DIFF
--- a/src/cli/domain/init-template/index.ts
+++ b/src/cli/domain/init-template/index.ts
@@ -21,6 +21,11 @@ export default async function initTemplate(options: {
   await npm.init(npmOptions);
   await installTemplate(options);
   await scaffold(Object.assign(options, { compilerPath }));
+  await npm.installDependencies({
+    installPath: componentPath,
+    silent: true,
+    usePrefix: true
+  });
 
   return { ok: true };
 }

--- a/src/utils/npm-utils.ts
+++ b/src/utils/npm-utils.ts
@@ -4,6 +4,7 @@ import stripVersion from './strip-version';
 
 const buildInstallCommand = (options: {
   installPath: string;
+  all?: boolean;
   save?: boolean;
   isDev?: boolean;
   usePrefix: boolean;
@@ -13,6 +14,8 @@ const buildInstallCommand = (options: {
   if (options.usePrefix) {
     args.push('--prefix', options.installPath);
   }
+
+  if (options.all) return args;
 
   if (options.save) {
     args.push('--save-exact');
@@ -66,22 +69,26 @@ export const init = (options: {
 };
 
 export const installDependencies = async (options: {
-  dependencies: string[];
+  dependencies?: string[];
   installPath: string;
   silent: boolean;
   usePrefix: boolean;
 }): Promise<{ dest: string[] }> => {
   const { dependencies, installPath, silent } = options;
-  const npmi = buildInstallCommand(options);
+  const npmi = buildInstallCommand({
+    ...options,
+    all: !dependencies?.length
+  });
   const cmdOptions = {
-    command: [...npmi, ...dependencies],
+    command: [...npmi, ...(dependencies ?? [])],
     path: installPath,
     silent
   };
 
-  const dest = dependencies.map((dependency) =>
-    getFullPath({ installPath, dependency })
-  );
+  const dest =
+    dependencies?.map((dependency) =>
+      getFullPath({ installPath, dependency })
+    ) ?? [];
 
   await executeCommand(cmdOptions);
 

--- a/test/unit/cli-domain-init-template.js
+++ b/test/unit/cli-domain-init-template.js
@@ -14,7 +14,8 @@ describe('cli : domain : init-template', () => {
         'node:path': { join: (...args) => args.join('/') },
         './install-template': stubs.installTemplateStub,
         '../../../utils/npm-utils': {
-          init: stubs.npmStub
+          init: stubs.npmStub,
+          installDependencies: stubs.npmStub
         },
         './scaffold': stubs.scaffoldStub
       }
@@ -82,6 +83,14 @@ describe('cli : domain : init-template', () => {
       expect(o.componentName).to.equal('new-component');
       expect(o.componentPath).to.equal('path/to/new-component');
       expect(o.templateType).to.equal('oc-template-react');
+    });
+
+    it('should call npm install with correct parameters', () => {
+      expect(npmStub.args[1][0]).to.deep.equal({
+        installPath: 'path/to/new-component',
+        silent: true,
+        usePrefix: true
+      });
     });
   });
 


### PR DESCRIPTION
When doing "oc init", you are told by the terminal that you can start typing "oc dev . 3030" right away. This is not true for templates that require more than the compiler to run. My guess is that, initially, legacy templates didn't need anything else apart from the compiler, so installing the compiler to get the scaffolder was enough, but this is not the case for everything else (react, vue, solid, elm...), so, since we are already installing the compiler, this will also install everything else.