### PR TITLE
serve client dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",
     "oc-client": "^4.0.1",
-    "oc-client-browser": "^1.7.12",
+    "oc-client-browser": "^1.8.0",
     "oc-empty-response-handler": "^1.0.2",
     "oc-get-unix-utc-timestamp": "^1.0.6",
     "oc-s3-storage-adapter": "^2.2.0",

--- a/src/registry/domain/repository.ts
+++ b/src/registry/domain/repository.ts
@@ -268,11 +268,11 @@ export default function repository(conf: Config) {
 
       return dotenv.parse(file);
     },
-    getStaticClientPath: (): string =>
+    getStaticClientPath: (dev?: boolean): string =>
       `${options!['path']}${getFilePath(
         'oc-client',
         packageInfo.version,
-        'src/oc-client.min.js'
+        dev ? 'src/oc-client.js' : 'src/oc-client.min.js'
       )}`,
 
     getStaticClientMapPath: (): string =>

--- a/src/registry/router.ts
+++ b/src/registry/router.ts
@@ -33,6 +33,7 @@ export function create(app: Express, conf: Config, repository: Repository) {
   }
 
   app.get(`${prefix}oc-client/client.js`, routes.staticRedirector);
+  app.get(`${prefix}oc-client/client.dev.js`, routes.staticRedirector);
   app.get(`${prefix}oc-client/oc-client.min.map`, routes.staticRedirector);
 
   app.get(`${prefix}~registry/plugins`, routes.plugins);

--- a/src/registry/routes/static-redirector.ts
+++ b/src/registry/routes/static-redirector.ts
@@ -9,11 +9,12 @@ export default function staticRedirector(repository: Repository) {
   return (req: Request, res: Response): void => {
     let filePath: string;
     const clientPath = `${res.conf.prefix || '/'}oc-client/client.js`;
+    const devClientPath = `${res.conf.prefix || '/'}oc-client/client.dev.js`;
     const clientMapPath = `${
       res.conf.prefix || '/'
     }oc-client/oc-client.min.map`;
 
-    if (req.route.path === clientPath) {
+    if (req.route.path === clientPath || req.route.path === devClientPath) {
       if (res.conf.local) {
         if (res.conf.compiledClient) {
           res.type('application/javascript');
@@ -27,10 +28,16 @@ export default function staticRedirector(repository: Repository) {
       } else {
         if (res.conf.compiledClient) {
           res.type('application/javascript');
-          res.send(res.conf.compiledClient.code);
+          res.send(
+            req.route.path === clientPath
+              ? res.conf.compiledClient.code
+              : res.conf.compiledClient.dev
+          );
           return;
         }
-        res.redirect(repository.getStaticClientPath());
+        res.redirect(
+          repository.getStaticClientPath(req.route.path === devClientPath)
+        );
         return;
       }
     } else if (req.route.path === clientMapPath) {


### PR DESCRIPTION
`/oc-client/client.dev.js` will know serve the unminified version, which is useful if you want in local to use the precompiled version of your own registry, but unminified for debugging purposes.