### PR TITLE
compress compiled client

### DIFF
--- a/src/registry/middleware/compression.ts
+++ b/src/registry/middleware/compression.ts
@@ -1,0 +1,22 @@
+import type { Request, Response } from 'express';
+
+export default function compress(
+  data: { uncompressed: string; brotli: Buffer; gzip: Buffer },
+  req: Request,
+  res: Response
+) {
+  const accept = req.headers['accept-encoding'];
+  const encoding =
+    typeof accept === 'string' &&
+    (accept.match(/\bbr\b/) || accept.match(/\bgzip\b/) || [])[0];
+
+  if (!encoding) {
+    res.send(data.uncompressed);
+    return;
+  }
+
+  res.setHeader('Content-Encoding', encoding);
+  const compressed = encoding === 'br' ? data.brotli : data.gzip;
+
+  res.send(compressed);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,11 @@ export type PublishAuthConfig =
 
 export interface Config<T = any> {
   baseUrl: string;
-  compiledClient?: { code: string; map: string; dev: string };
+  compiledClient?: {
+    code: { gzip: Buffer; brotli: Buffer; minified: string };
+    map: string;
+    dev: string;
+  };
   baseUrlFunc?: (opts: { host?: string; secure: boolean }) => string;
   beforePublish: (req: Request, res: Response, next: NextFunction) => void;
   customHeadersToSkipOnWeakVersion: string[];


### PR DESCRIPTION
This compresses and caches the compiled oc-client, to serve as fast possible. I'm only compressing oc-client and caching it, since the other routes don't make as much sense to do, an it gives a boost in performance in comparison of just using `app.use(compress())` on the express instance.

### Using compress library

| Stat      | 2.5%   | 50%    | 97.5%  | 99%    | Avg        | Stdev     | Max     |
|-----------|--------|--------|--------|--------|------------|-----------|---------|
| Latency   | 102 ms | 119 ms | 129 ms | 131 ms | 119.94 ms  | 46.47 ms  | 2929 ms |

| Stat      | 1%     | 2.5%   | 50%    | 97.5%  | Avg        | Stdev     | Min     |
|-----------|--------|--------|--------|--------|------------|-----------|---------|
| Req/Sec   | 7,163  | 7,163  | 8,359  | 8,495  | 8,292.71   | 231.73    | 7,163   |
| Bytes/Sec | 67.1 MB| 67.1 MB| 78.3 MB| 79.6 MB| 77.7 MB    | 2.17 MB   | 67.1 MB |

---

### Optimized Compression

| Stat      | 2.5%   | 50%    | 97.5%  | 99%    | Avg        | Stdev     | Max     |
|-----------|--------|--------|--------|--------|------------|-----------|---------|
| Latency   | 93 ms  | 106 ms | 121 ms | 123 ms | 107.56 ms  | 25.97 ms  | 1913 ms |

| Stat      | 1%     | 2.5%   | 50%    | 97.5%  | Avg        | Stdev     | Min     |
|-----------|--------|--------|--------|--------|------------|-----------|---------|
| Req/Sec   | 8,319  | 8,319  | 9,255  | 9,447  | 9,243      | 183.74    | 8,319   |
| Bytes/Sec | 77.8 MB| 77.8 MB| 86.5 MB| 88.3 MB| 86.4 MB    | 1.71 MB   | 77.7 MB |