### PR TITLE
remove got, replace with undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "getport": "^0.1.0",
         "livereload": "^0.9.3",
         "lodash.isequal": "^4.5.0",
-        "minimal-request": "^3.0.0",
         "morgan": "^1.10.0",
         "multer": "^1.4.3",
         "nice-cache": "^0.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "form-data": "^4.0.0",
         "fs-extra": "^11.2.0",
         "getport": "^0.1.0",
-        "got": "^11.8.5",
         "livereload": "^0.9.3",
         "lodash.isequal": "^4.5.0",
         "minimal-request": "^3.0.0",
@@ -53,6 +52,7 @@
         "serialize-error": "^8.1.0",
         "targz": "^1.0.1",
         "try-require": "^1.2.1",
+        "undici": "^6.19.8",
         "universalify": "^2.0.0",
         "yargs": "^17.7.2"
       },
@@ -67,7 +67,6 @@
         "@types/errorhandler": "^1.5.3",
         "@types/express": "^4.17.21",
         "@types/fs-extra": "^11.0.4",
-        "@types/got": "^9.6.12",
         "@types/livereload": "^0.9.5",
         "@types/morgan": "^1.9.9",
         "@types/multer": "^1.4.12",
@@ -2638,17 +2637,6 @@
         "win32"
       ]
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
@@ -2684,17 +2672,6 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@types/accept-language-parser": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/accept-language-parser/-/accept-language-parser-1.5.6.tgz",
@@ -2728,17 +2705,6 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/connect": {
@@ -2825,36 +2791,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/got": {
-      "version": "9.6.12",
-      "resolved": "https://registry.npmjs.org/@types/got/-/got-9.6.12.tgz",
-      "integrity": "sha512-X4pj/HGHbXVLqTpKjA2ahI4rV/nNBc9mGO2I/0CgAra+F2dKgMXnENv2SRpemScBzBAI4vMelIVYViQxlSE6xA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      }
-    },
-    "node_modules/@types/got/node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -2871,14 +2807,6 @@
       "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
       "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
       "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2975,14 +2903,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -3037,12 +2957,6 @@
       "dependencies": {
         "@types/tar-fs": "*"
       }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.9",
@@ -4325,31 +4239,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -4530,17 +4419,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -4760,31 +4638,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -4795,14 +4648,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -5436,20 +5281,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/getport": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/getport/-/getport-0.1.0.tgz",
@@ -5501,30 +5332,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -5661,11 +5468,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -5680,18 +5482,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -5930,11 +5720,6 @@
         "jsesc": "bin/jsesc"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -6085,14 +5870,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
-    },
-    "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
     },
     "node_modules/kind-of": {
       "version": "3.2.2",
@@ -6406,14 +6183,6 @@
         "get-func-name": "^2.0.1"
       }
     },
-    "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6561,14 +6330,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minimal-request": {
@@ -6914,17 +6675,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -7819,14 +7569,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -8095,15 +7837,6 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="
     },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8125,17 +7858,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/randombytes": {
@@ -8294,11 +8016,6 @@
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
       "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="
     },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
-    },
     "node_modules/response-time": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
@@ -8317,17 +8034,6 @@
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/right-align": {
@@ -9106,6 +8812,15 @@
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
       "optional": true
+    },
+    "node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "getport": "^0.1.0",
     "livereload": "^0.9.3",
     "lodash.isequal": "^4.5.0",
-    "minimal-request": "^3.0.0",
     "morgan": "^1.10.0",
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@types/errorhandler": "^1.5.3",
     "@types/express": "^4.17.21",
     "@types/fs-extra": "^11.0.4",
-    "@types/got": "^9.6.12",
     "@types/livereload": "^0.9.5",
     "@types/morgan": "^1.9.9",
     "@types/multer": "^1.4.12",
@@ -90,7 +89,6 @@
     "form-data": "^4.0.0",
     "fs-extra": "^11.2.0",
     "getport": "^0.1.0",
-    "got": "^11.8.5",
     "livereload": "^0.9.3",
     "lodash.isequal": "^4.5.0",
     "minimal-request": "^3.0.0",
@@ -119,6 +117,7 @@
     "serialize-error": "^8.1.0",
     "targz": "^1.0.1",
     "try-require": "^1.2.1",
+    "undici": "^6.19.8",
     "universalify": "^2.0.0",
     "yargs": "^17.7.2"
   }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -76,28 +76,3 @@ declare module 'nice-cache' {
 
   export = Cache;
 }
-
-declare module 'minimal-request' {
-  function request<T>(
-    opts: {
-      method?: string;
-      body?: unknown;
-      url: string;
-      headers?: Record<string, string | null | undefined | string[]>;
-      json?: boolean;
-    },
-    cb: (
-      err: Error | number | null,
-      body: T,
-      details: {
-        response: {
-          headers: Record<string, string>;
-        };
-      }
-    ) => void
-  ): void;
-
-  const req: Request;
-
-  export = request;
-}

--- a/src/registry/routes/helpers/is-url-discoverable.ts
+++ b/src/registry/routes/helpers/is-url-discoverable.ts
@@ -1,12 +1,11 @@
-import got from 'got';
+import { request } from 'undici';
 
 export default async function isUrlDiscoverable(
   url: string
 ): Promise<{ isDiscoverable: boolean }> {
   try {
-    const res = await got(url, {
-      headers: { accept: 'text/html' }
-    });
+    const res = await request(url, { headers: { accept: 'text/html' } });
+
     const isHtml = !!res.headers['content-type']?.includes('text/html');
 
     return {

--- a/src/utils/put.ts
+++ b/src/utils/put.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import FormData from 'form-data';
 import fs from 'fs-extra';
-import got from 'got';
+import { request } from 'undici';
 
 async function put(
   urlPath: string,
@@ -19,17 +19,17 @@ async function put(
     form.append(fileName, fs.createReadStream(file));
   }
 
-  const res = await got(urlPath, {
+  const res = await request(urlPath, {
     headers: { ...headers, ...form.getHeaders() },
     method: 'PUT',
     body: form
   });
 
   if (res.statusCode !== 200) {
-    throw res.body;
+    throw res.body.text();
   }
 
-  return res.body;
+  return res.body.text();
 }
 
 export default put;

--- a/test/acceptance/registry-ui.js
+++ b/test/acceptance/registry-ui.js
@@ -1,7 +1,7 @@
 const expect = require('chai').expect;
 const oc = require('../../dist/index');
 const path = require('node:path');
-const got = require('got');
+const { request } = require('undici');
 
 describe('registry (ui interface)', () => {
   let registry;
@@ -11,9 +11,9 @@ describe('registry (ui interface)', () => {
 
   const next = (promise, done) => {
     promise
-      .then((r) => {
+      .then(async (r) => {
         headers = r.headers;
-        result = r.body;
+        result = await r.body.text();
       })
       .catch((e) => {
         error = e;
@@ -44,7 +44,7 @@ describe('registry (ui interface)', () => {
   describe('GET / with Accept: text/html', () => {
     before((done) => {
       next(
-        got('http://localhost:3030', {
+        request('http://localhost:3030', {
           headers: { accept: 'text/html' }
         }),
         done
@@ -64,7 +64,7 @@ describe('registry (ui interface)', () => {
   describe('GET /oc-client/~info with Accept: text/html', () => {
     before((done) => {
       next(
-        got('http://localhost:3030/oc-client/~info', {
+        request('http://localhost:3030/oc-client/~info', {
           headers: { accept: 'text/html' }
         }),
         done

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -97,14 +97,15 @@ describe('registry', () => {
 
     describe('with a custom configuration with customHeadersToSkipOnWeakVersion defined', () => {
       before((done) => {
-        registry.close();
-        initializeRegistry(
-          {
-            ...getDefaultTestConfiguration(),
-            customHeadersToSkipOnWeakVersion: ['Cache-Control']
-          },
-          done
-        );
+        registry.close(() => {
+          initializeRegistry(
+            {
+              ...getDefaultTestConfiguration(),
+              customHeadersToSkipOnWeakVersion: ['Cache-Control']
+            },
+            done
+          );
+        });
       });
 
       after((done) => {
@@ -257,14 +258,15 @@ describe('registry', () => {
 
     describe('with a custom configuration with customHeadersToSkipOnWeakVersion defined', () => {
       before((done) => {
-        registry.close();
-        initializeRegistry(
-          {
-            ...getDefaultTestConfiguration(),
-            customHeadersToSkipOnWeakVersion: ['Cache-Control']
-          },
-          done
-        );
+        registry.close(() => {
+          initializeRegistry(
+            {
+              ...getDefaultTestConfiguration(),
+              customHeadersToSkipOnWeakVersion: ['Cache-Control']
+            },
+            done
+          );
+        });
       });
 
       after((done) => {

--- a/test/acceptance/registry/registry-with-fallback.js
+++ b/test/acceptance/registry/registry-with-fallback.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 const path = require('node:path');
-const got = require('got');
+const { request } = require('undici');
 
 describe('registry', () => {
   describe('when fallbackRegistryUrl is specified', () => {
@@ -28,8 +28,8 @@ describe('registry', () => {
 
     const next = (promise, done) => {
       promise
-        .then((r) => {
-          result = JSON.parse(r.body);
+        .then(async (r) => {
+          result = await r.body.json();
         })
         .finally(done);
     };
@@ -61,7 +61,7 @@ describe('registry', () => {
 
     describe('GET /welcome', () => {
       before((done) => {
-        next(got('http://localhost:3030/welcome'), done);
+        next(request('http://localhost:3030/welcome'), done);
       });
 
       it('should respond with the local registry url', () => {
@@ -75,7 +75,7 @@ describe('registry', () => {
 
     describe('GET /fallback-hello-world', () => {
       before((done) => {
-        next(got('http://localhost:3030/fallback-hello-world'), done);
+        next(request('http://localhost:3030/fallback-hello-world'), done);
       });
 
       it('should respond with the fallback registry url', () => {
@@ -92,7 +92,7 @@ describe('registry', () => {
     describe('GET /fallback-hello-world/~info', () => {
       before((done) => {
         next(
-          got(
+          request(
             'http://localhost:3030/fallback-welcome-with-optional-parameters/~info'
           ),
           done
@@ -111,7 +111,7 @@ describe('registry', () => {
     describe('GET /fallback-hello-world/~preview', () => {
       before((done) => {
         next(
-          got(
+          request(
             'http://localhost:3030/fallback-welcome-with-optional-parameters/~preview'
           ),
           done

--- a/test/unit/registry-routes-dependencies.js
+++ b/test/unit/registry-routes-dependencies.js
@@ -9,8 +9,8 @@ describe('registry : routes : plugins', () => {
       name: 'fs',
       link: 'http://link1.com'
     },
-    got: {
-      name: 'got',
+    undici: {
+      name: 'undici',
       version: '1.2.3',
       core: false,
       link: 'http://link2.com'
@@ -37,7 +37,7 @@ describe('registry : routes : plugins', () => {
     before(() => {
       initialise();
       const conf = {
-        dependencies: ['fs', 'got'],
+        dependencies: ['fs', 'undici'],
         discovery: false
       };
       dependenciesRoute = DependenciesRoute(conf);
@@ -54,7 +54,7 @@ describe('registry : routes : plugins', () => {
     before(() => {
       initialise();
       const conf = {
-        dependencies: ['fs', 'got'],
+        dependencies: ['fs', 'undici'],
         discovery: true
       };
       dependenciesRoute = DependenciesRoute(conf);
@@ -65,7 +65,7 @@ describe('registry : routes : plugins', () => {
     it('should return the list of dependencies', () => {
       expect(resJsonStub.args[0][0]).to.eql([
         { name: 'fs', core: true },
-        { name: 'got', core: false, versions: ['1.2.3'] }
+        { name: 'undici', core: false, versions: ['1.2.3'] }
       ]);
     });
   });

--- a/test/unit/registry-routes-helpers-is-url-discoverable.js
+++ b/test/unit/registry-routes-helpers-is-url-discoverable.js
@@ -8,12 +8,14 @@ describe('registry : routes : helpers : is-url-discoverable', () => {
       const isDiscoverable = injectr(
         '../../dist/registry/routes/helpers/is-url-discoverable.js',
         {
-          got: () =>
-            Promise.resolve({
-              headers: {
-                'content-type': 'application/json; charset=utf-8'
-              }
-            })
+          undici: {
+            request: () =>
+              Promise.resolve({
+                headers: {
+                  'content-type': 'application/json; charset=utf-8'
+                }
+              })
+          }
         }
       ).default;
 
@@ -35,12 +37,14 @@ describe('registry : routes : helpers : is-url-discoverable', () => {
       const isDiscoverable = injectr(
         '../../dist/registry/routes/helpers/is-url-discoverable.js',
         {
-          got: () =>
-            Promise.resolve({
-              headers: {
-                'content-type': 'text/html; charset=utf-8'
-              }
-            })
+          undici: {
+            request: () =>
+              Promise.resolve({
+                headers: {
+                  'content-type': 'text/html; charset=utf-8'
+                }
+              })
+          }
         }
       ).default;
 


### PR DESCRIPTION
Replaced `got` with `undici`, since got moving forward only supports ESM, and [undici is faster anyway](https://github.com/nodejs/undici?tab=readme-ov-file#benchmarks)