### PR TITLE
oc-client-browser@1.95 [ALLOW EMPTY ACTIONS]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc",
-  "version": "0.49.64",
+  "version": "0.49.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc",
-      "version": "0.49.64",
+      "version": "0.49.66",
       "license": "MIT",
       "dependencies": {
         "@types/lodash.isequal": "^4.5.8",
@@ -30,7 +30,7 @@
         "multer": "^1.4.3",
         "nice-cache": "^0.0.5",
         "oc-client": "^4.0.1",
-        "oc-client-browser": "^1.9.4",
+        "oc-client-browser": "^1.9.5",
         "oc-empty-response-handler": "^1.0.2",
         "oc-get-unix-utc-timestamp": "^1.0.6",
         "oc-s3-storage-adapter": "^2.2.0",
@@ -7234,9 +7234,9 @@
       }
     },
     "node_modules/oc-client-browser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.9.4.tgz",
-      "integrity": "sha512-FKierFJaph+WIfHklZYqPuCe/N50OUou0zI+esQm4u/uCrQ17QwP/WllqwEnlABfegXmBdsdmcfPgp1u6Mwkdw==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-1.9.5.tgz",
+      "integrity": "sha512-6Dkci395rEjHhGuYXh9ncG8uhO1ObLuTkqKfPhdLmz7PPtaypm80US4PyuO3v1SwKmyytuk1b9MB1kUaTCnxdQ==",
       "license": "MIT",
       "dependencies": {
         "uglify-js": "3.14.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",
     "oc-client": "^4.0.1",
-    "oc-client-browser": "^1.9.4",
+    "oc-client-browser": "^1.9.5",
     "oc-empty-response-handler": "^1.0.2",
     "oc-get-unix-utc-timestamp": "^1.0.6",
     "oc-s3-storage-adapter": "^2.2.0",


### PR DESCRIPTION
Update to 1.9.5, which allows for calling empty actions without throwing