### PR TITLE
add a min oc version checker for templates if defined

### DIFF
--- a/src/registry/domain/validators/index.ts
+++ b/src/registry/domain/validators/index.ts
@@ -5,6 +5,7 @@ import ocCliVersionValidator from './oc-cli-version';
 import packageJsonValidator from './package-json-validator';
 import pluginsRequirementsValidator from './plugins-requirements';
 import registryConfigurationValidator from './registry-configuration';
+import templateOcVersionValidator from './templace-oc-version';
 
 import nodeVersionValidator from './node-version';
 import uploadedPackageValidator from './uploaded-package';
@@ -19,6 +20,8 @@ export const validatePackage = uploadedPackageValidator;
 export const validatePackageJson = packageJsonValidator;
 export const validatePluginsRequirements = pluginsRequirementsValidator;
 export const validateRegistryConfiguration = registryConfigurationValidator;
+export const validateTemplateOcVersion = templateOcVersionValidator;
+
 export function validateVersion(version: string): boolean {
   return !!semver.valid(version);
 }

--- a/src/registry/domain/validators/templace-oc-version.ts
+++ b/src/registry/domain/validators/templace-oc-version.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import semver from 'semver';
+
+const packageInfo = fs.readJsonSync(
+  path.join(__dirname, '..', '..', '..', '..', 'package.json')
+);
+
+type OkResult = { isValid: true };
+type ErrorResult = {
+  isValid: false;
+  error: {
+    registryVersion: string;
+    minOcVersion: string;
+    code: string;
+  };
+};
+type Result = OkResult | ErrorResult;
+
+export default function templateOcVersion(minOcVersion: string): Result {
+  if (semver.lt(packageInfo.version, minOcVersion)) {
+    return {
+      isValid: false,
+      error: {
+        registryVersion: packageInfo.version,
+        minOcVersion,
+        code: 'old_version'
+      }
+    };
+  }
+
+  return { isValid: true };
+}

--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -213,7 +213,10 @@ export default function getComponent(conf: Config, repository: Repository) {
               status: 400,
               response: {
                 code: 'TEMPLATE_REQUIRES_HIGHER_OC_VERSION',
-                error: `Your template requires a version of OC higher than ${templateOcVersionResult.error.minOcVersion} but your OC version is ${templateOcVersionResult.error.registryVersion}`
+                error: strings.errors.cli.TEMPLATE_OC_VERSION_NOT_VALID(
+                  templateOcVersionResult.error.minOcVersion,
+                  templateOcVersionResult.error.registryVersion
+                )
               }
             });
           }

--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -18,6 +18,7 @@ import RequireWrapper from '../../domain/require-wrapper';
 import * as sanitiser from '../../domain/sanitiser';
 import * as urlBuilder from '../../domain/url-builder';
 import * as validator from '../../domain/validators';
+import { validateTemplateOcVersion } from '../../domain/validators';
 import applyDefaultValues from './apply-default-values';
 import * as getComponentFallback from './get-component-fallback';
 import GetComponentRetrievingInfo from './get-component-retrieving-info';
@@ -201,6 +202,21 @@ export default function getComponent(conf: Config, repository: Repository) {
               error: validationResult.errors.message
             }
           });
+        }
+
+        if (component.oc.files.template.minOcVersion) {
+          const templateOcVersionResult = validateTemplateOcVersion(
+            component.oc.files.template.minOcVersion
+          );
+          if (!templateOcVersionResult.isValid) {
+            return callback({
+              status: 400,
+              response: {
+                code: 'TEMPLATE_REQUIRES_HIGHER_OC_VERSION',
+                error: `Your template requires a version of OC higher than ${templateOcVersionResult.error.minOcVersion} but your OC version is ${templateOcVersionResult.error.registryVersion}`
+              }
+            });
+          }
         }
 
         // Support legacy templates

--- a/src/registry/routes/publish.ts
+++ b/src/registry/routes/publish.ts
@@ -65,7 +65,10 @@ export default function publish(repository: Repository) {
           res.errorDetails = `Your template requires a version of OC higher than ${templateOcVersionResult.error.minOcVersion}`;
           res.status(409).json({
             code: 'template_oc_version_not_valid',
-            error: `Your template requires a version of OC higher than ${templateOcVersionResult.error.minOcVersion} but your OC version is ${templateOcVersionResult.error.registryVersion}`,
+            error: strings.errors.cli.TEMPLATE_OC_VERSION_NOT_VALID(
+              templateOcVersionResult.error.minOcVersion,
+              templateOcVersionResult.error.registryVersion
+            ),
             details: templateOcVersionResult.error
           });
           return;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -212,6 +212,11 @@ export default {
         `Error requiring oc-template: "${template}" not found`,
       TEMPLATE_TYPE_NOT_VALID: (template: string): string =>
         `Error requiring oc-template: "${template}" is not a valid oc-template`,
+      TEMPLATE_OC_VERSION_NOT_VALID: (
+        template: string,
+        version: string
+      ): string =>
+        `Your template requires a version of OC higher than ${template} but your OC version is ${version}`,
       TEMPLATE_DEP_MISSING: (template: string, path: string): string =>
         `Template dependency missing. To fix it run:\n\nnpm install --save-dev ${template}-compiler --prefix ${path}\n\n`
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ interface OcConfiguration {
       src: string;
       type: string;
       version: string;
+      minOcVersion?: string;
       size?: number;
     };
     env?: string;


### PR DESCRIPTION
This adds the possibility of template compilers to add a new field `oc.template.minOcVersion` to specify a minimum OC version where it can run. This will be checked when publishing and when getting the component (mainly for local dev). This helps in scenarios where templates start using new features on OC that require a minimum version, but it's still optional so it doesn't break backwards.