### PR TITLE
Support stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc",
-  "version": "0.49.66",
+  "version": "0.49.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc",
-      "version": "0.49.66",
+      "version": "0.49.67",
       "license": "MIT",
       "dependencies": {
         "@types/lodash.isequal": "^4.5.8",
@@ -51,6 +51,7 @@
         "serialize-error": "^8.1.0",
         "targz": "^1.0.1",
         "try-require": "^1.2.1",
+        "turbo-stream": "^2.4.1",
         "undici": "^6.19.8",
         "universalify": "^2.0.0",
         "yargs": "^17.7.2"
@@ -9213,6 +9214,12 @@
       "engines": {
         "node": ">=0.6.x"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
+      "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==",
+      "license": "ISC"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "serialize-error": "^8.1.0",
     "targz": "^1.0.1",
     "try-require": "^1.2.1",
+    "turbo-stream": "^2.4.1",
     "undici": "^6.19.8",
     "universalify": "^2.0.0",
     "yargs": "^17.7.2"

--- a/src/registry/domain/require-wrapper.ts
+++ b/src/registry/domain/require-wrapper.ts
@@ -5,7 +5,9 @@ import tryRequire from 'try-require';
 
 import strings from '../../resources';
 
-const isCoreDependency = (x: string) => coreModules.includes(x);
+const allCoreModules = [...coreModules, ...coreModules.map((m) => `node:${m}`)];
+
+const isCoreDependency = (x: string) => allCoreModules.includes(x);
 const requireCoreDependency = (x: string) =>
   (isCoreDependency(x) && tryRequire(x)) || undefined;
 

--- a/src/registry/routes/component.ts
+++ b/src/registry/routes/component.ts
@@ -50,7 +50,6 @@ export default function component(
             res.set(result.headers);
           }
 
-          res.status(result.status);
           const streamEnabled =
             !!result.response.data?.component?.props?.[stream];
           if (streamEnabled) {
@@ -59,6 +58,7 @@ export default function component(
 
             const nodeStream = Readable.from(webStream);
 
+            res.status(result.status);
             nodeStream.on('error', (err) => {
               res.status(500).end(String(err));
             });
@@ -69,7 +69,7 @@ export default function component(
               res.end();
             });
           } else {
-            res.json(result.response);
+            res.status(result.status).json(result.response);
           }
         } catch (e) {
           res.status(500).json({

--- a/src/registry/routes/helpers/get-component.ts
+++ b/src/registry/routes/helpers/get-component.ts
@@ -55,6 +55,7 @@ export interface GetComponentResult {
   };
 }
 
+export const stream = Symbol('stream');
 const noop = () => {};
 const noopConsole = Object.fromEntries(
   Object.keys(console).map((key) => [key, noop])
@@ -501,7 +502,8 @@ export default function getComponent(conf: Config, repository: Repository) {
                   responseHeaders[header.toLowerCase()] = value;
                 }
               },
-              templates: repository.getTemplatesInfo()
+              templates: repository.getTemplatesInfo(),
+              streamSymbol: stream
             };
 
             const setCallbackTimeout = () => {
@@ -554,6 +556,9 @@ export default function getComponent(conf: Config, repository: Repository) {
                     Buffer,
                     AbortController: globalThis?.AbortController,
                     AbortSignal: globalThis?.AbortSignal,
+                    Promise,
+                    Date,
+                    Symbol,
                     eval: undefined,
                     fetch: globalThis?.fetch
                   };


### PR DESCRIPTION
This adds stream support if the template passes the stream symbol back on the getData response. Allows to serialize almost any object, including promises. Will be added on v0.50.0 along with oc-client-browser v2