### PR TITLE
[v0.50.0] [BREAKING] Switch compile client default to true

### DIFF
--- a/src/registry/domain/options-sanitiser.ts
+++ b/src/registry/domain/options-sanitiser.ts
@@ -14,6 +14,11 @@ type CompileOptions = Omit<
 export interface RegistryOptions<T = any>
   extends Partial<Omit<Config<T>, 'beforePublish'>> {
   baseUrl: string;
+  /**
+   * Set the options for the oc-client-browser
+   * Set it to false to disable the compilation of the client
+   * @default true
+   */
   compileClient?: boolean | CompileOptions;
 }
 
@@ -65,9 +70,11 @@ export default function optionsSanitiser(input: RegistryOptions): Config {
     options.templates = [];
   }
 
-  if (options.compileClient) {
+  if (options.compileClient || options.compileClient !== false) {
     const clientOptions =
-      typeof options.compileClient === 'boolean' ? {} : options.compileClient;
+      typeof options.compileClient === 'boolean'
+        ? {}
+        : (options.compileClient ?? {});
 
     const compiled = compileSync({
       templates: options.templates,

--- a/test/unit/registry-domain-options-sanitiser.js
+++ b/test/unit/registry-domain-options-sanitiser.js
@@ -137,7 +137,11 @@ describe('registry : domain : options-sanitiser', () => {
 
   describe('when templates', () => {
     describe('is provided', () => {
-      const options = { baseUrl: 'dummy', templates: [{ name: 'hi' }] };
+      const options = {
+        baseUrl: 'dummy',
+        templates: [{ name: 'hi' }],
+        compileClient: false
+      };
       it('should not modify it', () => {
         expect(sanitise(options).templates).to.deep.equal([{ name: 'hi' }]);
       });


### PR DESCRIPTION
Switch compileClient default to true. So by default now the oc-client will be compiled at startup, to include the templates added to the registry, among possible options you could add as an object to the same property