### PR TITLE
Multiple logins

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,6 +1,32 @@
 declare module 'oc-client';
 declare module 'try-require';
-declare module 'basic-auth-connect';
+declare module 'basic-auth-connect' {
+  import type { IncomingMessage, ServerResponse } from 'node:http';
+
+  // Middleware function type
+  type Middleware = (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (err?: any) => void
+  ) => void;
+
+  // Sync callback function type
+  type SyncCallback = (user: string, pass: string) => boolean;
+
+  // Async callback function type
+  type AsyncCallback = (
+    user: string,
+    pass: string,
+    fn: (err: any, user?: any) => void
+  ) => void;
+
+  // Main function overloads
+  function basicAuth(username: string, password: string): Middleware;
+  function basicAuth(callback: SyncCallback): Middleware;
+  function basicAuth(callback: AsyncCallback): Middleware;
+
+  export = basicAuth;
+}
 
 declare module 'universalify' {
   export function fromCallback<

--- a/src/registry/domain/authentication.ts
+++ b/src/registry/domain/authentication.ts
@@ -4,12 +4,19 @@ import type { RequestHandler } from 'express';
 import strings from '../../resources/';
 import type { Authentication, PublishAuthConfig } from '../../types';
 
-const basicAuthentication: Authentication<{
-  username: string;
-  password: string;
-}> = {
+const basicAuthentication: Authentication<
+  | {
+      username: string;
+      password: string;
+    }
+  | { logins: Array<{ username: string; password: string }> }
+> = {
   validate(authConfig) {
-    const isValid = !!authConfig.username && !!authConfig.password;
+    const logins = 'logins' in authConfig ? authConfig.logins : [authConfig];
+
+    const isValid =
+      logins.length > 0 &&
+      logins.every((login) => !!login.username && !!login.password);
 
     return {
       isValid,
@@ -20,7 +27,11 @@ const basicAuthentication: Authentication<{
     };
   },
   middleware(authConfig) {
-    return basicAuth(authConfig.username, authConfig.password);
+    const logins = 'logins' in authConfig ? authConfig.logins : [authConfig];
+
+    return basicAuth((user, pass) =>
+      logins.some((login) => login.username === user && login.password === pass)
+    );
   }
 };
 

--- a/src/registry/domain/repository.ts
+++ b/src/registry/domain/repository.ts
@@ -307,12 +307,14 @@ export default function repository(conf: Config) {
       componentName,
       componentVersion,
       pkgDetails,
+      user,
       dryRun = false
     }: {
       pkgDetails: { outputFolder: string; packageJson: Component };
       componentName: string;
       componentVersion: string;
       dryRun?: boolean;
+      user?: string;
     }): Promise<void> {
       if (conf.local) {
         throw {
@@ -339,6 +341,7 @@ export default function repository(conf: Config) {
 
       const validationResult = validator.validatePackageJson(
         Object.assign(pkgDetails, {
+          context: { user },
           componentName,
           customValidator: conf.publishValidation
         })

--- a/src/registry/domain/validators/package-json-validator.ts
+++ b/src/registry/domain/validators/package-json-validator.ts
@@ -8,7 +8,13 @@ interface ValidationResult {
 interface PkgDetails {
   componentName: string;
   packageJson: { name?: string };
-  customValidator: (data: unknown) => ValidationResult | boolean;
+  context: {
+    user?: string;
+  };
+  customValidator: (
+    pkgJson: unknown,
+    context: { user?: string }
+  ) => ValidationResult | boolean;
 }
 
 export default function packageJsonValidator(
@@ -21,7 +27,10 @@ export default function packageJsonValidator(
     };
   }
 
-  let result = pkgDetails.customValidator(pkgDetails.packageJson);
+  let result = pkgDetails.customValidator(
+    pkgDetails.packageJson,
+    pkgDetails.context
+  );
 
   if (typeof result === 'boolean') {
     result = { isValid: result };

--- a/src/registry/routes/publish.ts
+++ b/src/registry/routes/publish.ts
@@ -80,7 +80,8 @@ export default function publish(repository: Repository) {
           pkgDetails,
           componentName: req.params['componentName'],
           componentVersion: req.params['componentVersion'],
-          dryRun: typeof req.query['dryRun'] !== 'undefined'
+          dryRun: typeof req.query['dryRun'] !== 'undefined',
+          user: req.user
         });
         res.status(200).json({ ok: true });
       } catch (err: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,10 @@ export type PublishAuthConfig =
       username: string;
       password: string;
     }
+  | {
+      type: 'basic';
+      logins: Array<{ username: string; password: string }>;
+    }
   | ({ type: string | Authentication } & Record<string, any>);
 
 export interface Config<T = any> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,7 +183,10 @@ export interface Config<T = any> {
   postRequestPayloadSize?: string | number;
   prefix: string;
   publishAuth?: PublishAuthConfig;
-  publishValidation: (data: unknown) =>
+  publishValidation: (
+    pkgJson: unknown,
+    context: { user?: string }
+  ) =>
     | {
         isValid: boolean;
         error?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,6 +259,9 @@ export interface Plugin<T = any> {
 
 declare global {
   namespace Express {
+    interface Request {
+      user?: string;
+    }
     interface Response {
       conf: Config;
       errorCode?: string;

--- a/test/unit/registry-domain-validator.js
+++ b/test/unit/registry-domain-validator.js
@@ -91,6 +91,63 @@ describe('registry : domain : validator', () => {
           });
         });
 
+        describe('when multiple logins specified', () => {
+          describe('when all logins have username and password', () => {
+            const conf = {
+              publishAuth: {
+                type: 'basic',
+                logins: [
+                  { username: 'user1', password: 'pass1' },
+                  { username: 'user2', password: 'pass2' }
+                ]
+              },
+              s3: baseS3Conf
+            };
+
+            it('should be valid', () => {
+              expect(validate(conf).isValid).to.be.true;
+            });
+          });
+
+          describe('when some logins are missing username or password', () => {
+            const conf = {
+              publishAuth: {
+                type: 'basic',
+                logins: [
+                  { username: 'user1', password: 'pass1' },
+                  { username: 'user2' },
+                  { password: 'pass3' }
+                ]
+              },
+              s3: baseS3Conf
+            };
+
+            it('should not be valid', () => {
+              expect(validate(conf).isValid).to.be.false;
+              expect(validate(conf).message).to.equal(
+                'Registry configuration is not valid: basic auth requires username and password'
+              );
+            });
+          });
+
+          describe('when logins array is empty', () => {
+            const conf = {
+              publishAuth: {
+                type: 'basic',
+                logins: []
+              },
+              s3: baseS3Conf
+            };
+
+            it('should not be valid', () => {
+              expect(validate(conf).isValid).to.be.false;
+              expect(validate(conf).message).to.equal(
+                'Registry configuration is not valid: basic auth requires username and password'
+              );
+            });
+          });
+        });
+
         describe('when username and password not specified', () => {
           const conf = {
             publishAuth: { type: 'basic', a: '' },


### PR DESCRIPTION
This allow to define multiple logins/passwords for Basic Auth in a non breaking way. For that matter, if available, the user from req.user will be passed for the publishAuth validation, so in your registry you can do authorisation logic based on that user.