### PR TITLE
update client to support unmounting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc",
-  "version": "0.50.8",
+  "version": "0.50.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc",
-      "version": "0.50.8",
+      "version": "0.50.9",
       "license": "MIT",
       "dependencies": {
         "@rdevis/turbo-stream": "^2.4.1",
@@ -31,7 +31,7 @@
         "multer": "^1.4.3",
         "nice-cache": "^0.0.5",
         "oc-client": "^4.0.2",
-        "oc-client-browser": "^2.0.4",
+        "oc-client-browser": "^2.1.1",
         "oc-empty-response-handler": "^1.0.2",
         "oc-get-unix-utc-timestamp": "^1.0.6",
         "oc-s3-storage-adapter": "^2.2.0",
@@ -7274,9 +7274,9 @@
       }
     },
     "node_modules/oc-client-browser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-2.0.4.tgz",
-      "integrity": "sha512-GxZqqGoKr8j9HQ+IQeXRBIin1fJO4KzU3rFsp9pXWbXuy//2r1r/sUEU77nCOJg+bNjSMcCaEjhhotDV9r62wQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-2.1.1.tgz",
+      "integrity": "sha512-1urtzhj5IDmGsgsar52sQ76ha7melCEtyZFKCHQcYD/8C51R08FwYA49focOObMOl17Bh1PZpOhnLi+6PHOIBA==",
       "license": "MIT",
       "dependencies": {
         "@rdevis/turbo-stream": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",
     "oc-client": "^4.0.2",
-    "oc-client-browser": "^2.0.4",
+    "oc-client-browser": "^2.1.1",
     "oc-empty-response-handler": "^1.0.2",
     "oc-get-unix-utc-timestamp": "^1.0.6",
     "oc-s3-storage-adapter": "^2.2.0",


### PR DESCRIPTION
This updates oc-client with support to automatic mounting/unmounting since now oc-components are custom elements and we attach them the connected/disconnected callbacks, and newer versions of the templates add an unmount function to the element that they can call