### PR TITLE
Leave preview open without discovery

### DIFF
--- a/src/registry/routes/component-preview.ts
+++ b/src/registry/routes/component-preview.ts
@@ -28,7 +28,7 @@ function componentPreview(
   const isHtmlRequest =
     !!req.headers.accept && req.headers.accept.indexOf('text/html') >= 0;
 
-  if (isHtmlRequest && !!res.conf.discovery) {
+  if (isHtmlRequest) {
     res.send(
       previewView({
         component,


### PR DESCRIPTION
The preview html has nothing to be discovered, is a simple html that could be prepared outside the registry, so I don't think there is any concern in terms of discovery and allows to preview it if you know the path (name/parameters)
