### PR TITLE
Add option to rate limit the publish endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "getport": "^0.1.0",
         "livereload": "^0.9.3",
         "lodash.isequal": "^4.5.0",
+        "lru-cache": "^11.1.0",
         "morgan": "^1.10.0",
         "multer": "^1.4.3",
         "nice-cache": "^0.0.5",
@@ -1438,6 +1439,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -6779,12 +6789,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/markdown": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "getport": "^0.1.0",
     "livereload": "^0.9.3",
     "lodash.isequal": "^4.5.0",
+    "lru-cache": "^11.1.0",
     "morgan": "^1.10.0",
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",

--- a/src/registry/domain/memory-rate-limit-store.ts
+++ b/src/registry/domain/memory-rate-limit-store.ts
@@ -1,0 +1,80 @@
+import { LRUCache } from 'lru-cache';
+import type { RateLimitStore } from '../../types';
+
+interface RateLimitEntry {
+  hits: number;
+  resetTime: number;
+}
+
+export default class MemoryRateLimitStore implements RateLimitStore {
+  private store: LRUCache<string, RateLimitEntry>;
+
+  constructor(maxSize: number = 1000) {
+    this.store = new LRUCache({
+      max: maxSize,
+      // TTL is handled manually in our increment logic
+      ttl: 0,
+      // Don't allow stale items
+      allowStale: false,
+      // Update age on access to maintain LRU behavior
+      updateAgeOnGet: true,
+      // Clean up expired entries when they're accessed
+      dispose: (_value, _key) => {
+        // Optional: log when entries are disposed
+      }
+    });
+  }
+
+  async increment(
+    key: string,
+    windowMs: number
+  ): Promise<{
+    totalHits: number;
+    resetTime: Date;
+  }> {
+    const now = Date.now();
+    const resetTime = new Date(now + windowMs);
+
+    const existing = this.store.get(key);
+
+    if (!existing || existing.resetTime < now) {
+      // New entry or expired entry
+      const entry: RateLimitEntry = {
+        hits: 1,
+        resetTime: now + windowMs
+      };
+      this.store.set(key, entry);
+      return {
+        totalHits: 1,
+        resetTime
+      };
+    }
+
+    // Increment existing entry
+    existing.hits++;
+    return {
+      totalHits: existing.hits,
+      resetTime: new Date(existing.resetTime)
+    };
+  }
+
+  async resetKey(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  // Clean up expired entries periodically
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.store.entries()) {
+      if (entry.resetTime < now) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  // Start cleanup interval
+  init(): void {
+    // Clean up expired entries every 5 minutes
+    setInterval(() => this.cleanup(), 5 * 60 * 1000);
+  }
+}

--- a/src/registry/middleware/publish-rate-limit.ts
+++ b/src/registry/middleware/publish-rate-limit.ts
@@ -1,0 +1,67 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { Config } from '../../types';
+import MemoryRateLimitStore from '../domain/memory-rate-limit-store';
+
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_MAX_HITS = 100;
+const DEFAULT_MAX_CACHE_SIZE = 1000; // Maximum number of rate limit entries to keep in memory
+
+function defaultKeyGenerator(req: Request): string {
+  return `${req.ip}:${req.user ?? 'anon'}`;
+}
+
+export default function createPublishRateLimiter(conf: Config) {
+  const rateLimitConfig = conf.publishRateLimit ?? {};
+  const windowMs = rateLimitConfig.windowMs ?? DEFAULT_WINDOW_MS;
+  const maxHits = rateLimitConfig.max ?? DEFAULT_MAX_HITS;
+  const keyGenerator = rateLimitConfig.keyGenerator ?? defaultKeyGenerator;
+  const skip = rateLimitConfig.skip;
+  const maxCacheSize = rateLimitConfig.maxCacheSize ?? DEFAULT_MAX_CACHE_SIZE;
+
+  // Use provided store or create memory store with configurable size
+  const store = rateLimitConfig.store ?? new MemoryRateLimitStore(maxCacheSize);
+
+  // Initialize store if it has an init method
+  if (store.init) {
+    store.init();
+  }
+
+  return async function publishRateLimiter(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      // Skip rate limiting if skip function returns true
+      if (skip?.(req)) {
+        return next();
+      }
+
+      const key = keyGenerator(req);
+      const { totalHits, resetTime } = await store.increment(key, windowMs);
+
+      if (totalHits > maxHits) {
+        // Calculate seconds until reset
+        const retryAfter = Math.ceil((resetTime.getTime() - Date.now()) / 1000);
+
+        res.set('Retry-After', retryAfter.toString());
+
+        res.status(429).json({
+          error: 'rate_limit_exceeded',
+          message: 'Too many publish requests',
+          resetTime: resetTime.toISOString(),
+          retryAfter
+        });
+
+        // Set Retry-After header
+        return;
+      }
+
+      next();
+    } catch (error) {
+      // If rate limiting fails, log error but allow request to proceed
+      console.error('Rate limiting error:', error);
+      next();
+    }
+  };
+}

--- a/src/registry/router.ts
+++ b/src/registry/router.ts
@@ -2,6 +2,7 @@ import type { Express } from 'express';
 import type { Repository } from '../registry/domain/repository';
 import settings from '../resources/settings';
 import type { Config } from '../types';
+import createPublishRateLimiter from './middleware/publish-rate-limit';
 import IndexRoute from './routes';
 import ComponentRoute from './routes/component';
 import ComponentInfoRoute from './routes/component-info';
@@ -28,6 +29,7 @@ export function create(app: Express, conf: Config, repository: Repository) {
   };
 
   const prefix = conf.prefix;
+  const publishRateLimiter = createPublishRateLimiter(conf);
 
   if (prefix !== '/') {
     app.get('/', (_req, res) => res.redirect(prefix));
@@ -50,6 +52,7 @@ export function create(app: Express, conf: Config, repository: Repository) {
   } else {
     app.put(
       `${prefix}:componentName/:componentVersion`,
+      publishRateLimiter,
       conf.beforePublish,
       routes.publish
     );


### PR DESCRIPTION
This adds an option to rate-limit the publish endpoint. By default it will use a memory one with lru-cache, but it's extendable by passing an object that follows the interface described so you could plug-in Redis or whatever library you want. I'm leaning towards enabling this by default