### PR TITLE
extend discovery options, add a way to filter states (experimental/deprecated), and also a way to hide experiments from api even

### DIFF
--- a/src/registry/domain/options-sanitiser.ts
+++ b/src/registry/domain/options-sanitiser.ts
@@ -12,7 +12,28 @@ type CompileOptions = Omit<
 >;
 
 export interface RegistryOptions<T = any>
-  extends Partial<Omit<Config<T>, 'beforePublish'>> {
+  extends Partial<Omit<Config<T>, 'beforePublish' | 'discovery'>> {
+  /**
+   * Configuration object to enable/disable the HTML discovery page and the API
+   *
+   * @default true
+   */
+  discovery?:
+    | {
+        /**
+         * Enables the HTML discovery page
+         *
+         * @default true
+         */
+        ui?: boolean;
+        /**
+         * Shows experimental components from the API
+         *
+         * @default true
+         */
+        experimental?: boolean;
+      }
+    | boolean;
   /**
    * Public base URL where the registry will be accessible by consumers.
    * It **must** already include the chosen {@link Config.prefix} and end with a trailing slash.
@@ -64,9 +85,20 @@ export default function optionsSanitiser(input: RegistryOptions): Config {
     options.verbosity = 0;
   }
 
-  if (typeof options.discovery === 'undefined') {
-    options.discovery = true;
-  }
+  const showUI =
+    typeof options.discovery === 'boolean'
+      ? options.discovery
+      : (options.discovery?.ui ?? true);
+  const showExperimental =
+    typeof options.discovery === 'boolean'
+      ? // We keep previous default behavior for backward compatibility
+        true
+      : (options.discovery?.experimental ?? true);
+
+  options.discovery = {
+    ui: showUI,
+    experimental: showExperimental
+  };
 
   if (typeof options.pollingInterval === 'undefined') {
     options.pollingInterval = 5;

--- a/src/registry/domain/validators/registry-configuration.ts
+++ b/src/registry/domain/validators/registry-configuration.ts
@@ -5,7 +5,7 @@ import * as auth from '../authentication';
 type ValidationResult = { isValid: true } | { isValid: false; message: string };
 
 export default function registryConfiguration(
-  conf: Partial<Config>
+  conf: Partial<Omit<Config, 'discovery'>>
 ): ValidationResult {
   const returnError = (message: string): ValidationResult => {
     return {

--- a/src/registry/middleware/discovery-handler.ts
+++ b/src/registry/middleware/discovery-handler.ts
@@ -10,7 +10,7 @@ export default function discoveryHandler(
     (typeof res.conf.discovery === 'function' ? res.conf.discovery : undefined);
 
   if (res.conf.discoveryFunc) {
-    res.conf.discovery = res.conf.discoveryFunc({
+    res.conf.discovery.ui = res.conf.discoveryFunc({
       host: req.headers.host,
       secure: req.secure
     });

--- a/src/registry/routes/component-info.ts
+++ b/src/registry/routes/component-info.ts
@@ -49,7 +49,7 @@ function componentInfo(
   const isHtmlRequest =
     !!req.headers.accept && req.headers.accept.indexOf('text/html') >= 0;
 
-  if (isHtmlRequest && !!res.conf.discovery) {
+  if (isHtmlRequest && !!res.conf.discovery.ui) {
     const params = getParams(component);
     const parsedAuthor = getParsedAuthor(component);
     let href = res.conf.baseUrl;

--- a/src/registry/routes/dependencies.ts
+++ b/src/registry/routes/dependencies.ts
@@ -4,7 +4,7 @@ import getAvailableDependencies from './helpers/get-available-dependencies';
 
 export default function dependencies(conf: Config) {
   return (_req: Request, res: Response): void => {
-    if (res.conf.discovery) {
+    if (res.conf.discovery.ui) {
       const dependencies = getAvailableDependencies(conf.dependencies).map(
         ({ core, name, version }) => {
           const dep: { name: string; core: boolean; versions?: string[] } = {

--- a/src/registry/routes/history.ts
+++ b/src/registry/routes/history.ts
@@ -5,7 +5,7 @@ import getComponentsHistory from './helpers/get-components-history';
 export default function history(repository: Repository) {
   return async (_req: Request, res: Response): Promise<void> => {
     try {
-      if (res.conf.discovery && !res.conf.local) {
+      if (res.conf.discovery.ui && !res.conf.local) {
         const details = await repository.getComponentsDetails();
         const componentsHistory = getComponentsHistory(details);
         res.setHeader('Cache-Control', 'public, max-age=600');

--- a/src/registry/routes/index.ts
+++ b/src/registry/routes/index.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import async from 'async';
 import fs from 'fs-extra';
 import parseAuthor from 'parse-author';
 
@@ -10,9 +9,8 @@ import getAvailableDependencies from './helpers/get-available-dependencies';
 import urlBuilder = require('../domain/url-builder');
 
 import type { IncomingHttpHeaders } from 'node:http';
-import type { NextFunction, Request, Response } from 'express';
+import type { Request, Response } from 'express';
 import type { PackageJson } from 'type-fest';
-import { fromPromise } from 'universalify';
 import type { Author, Component, ParsedComponent } from '../../types';
 import type { Repository } from '../domain/repository';
 
@@ -32,92 +30,99 @@ const isHtmlRequest = (headers: IncomingHttpHeaders) =>
   !!headers.accept && headers.accept.indexOf('text/html') >= 0;
 
 export default function (repository: Repository) {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    fromPromise(repository.getComponents)((err, components) => {
-      if (err) {
-        res.errorDetails = 'cdn not available';
-        res.status(404).json({ error: res.errorDetails });
-        return;
-      }
+  return async (req: Request, res: Response): Promise<void> => {
+    let components: string[];
 
-      const baseResponse = {
-        href: res.conf.baseUrl,
-        ocVersion: packageInfo.version,
-        type: res.conf.local ? 'oc-registry-local' : 'oc-registry'
-      };
+    try {
+      components = await repository.getComponents();
+    } catch {
+      res.errorDetails = 'cdn not available';
+      res.status(404).json({ error: res.errorDetails });
+      return;
+    }
 
-      if (isHtmlRequest(req.headers) && !!res.conf.discovery) {
-        let componentsInfo: ParsedComponent[] = [];
-        let componentsReleases = 0;
-        const stateCounts: { deprecated?: number; experimental?: number } = {};
+    const baseResponse = {
+      href: res.conf.baseUrl,
+      ocVersion: packageInfo.version,
+      type: res.conf.local ? 'oc-registry-local' : 'oc-registry'
+    };
+    const componentResults = await Promise.all(
+      components.map((component) =>
+        repository.getComponent(component, undefined)
+      )
+    );
 
-        async.each(
-          components,
-          (component, callback) =>
-            fromPromise(repository.getComponent)(
-              component,
-              undefined,
-              (err, result) => {
-                if (err) return callback(err as any);
-
-                if (result.oc?.date) {
-                  result.oc.stringifiedDate = dateStringified(
-                    new Date(result.oc.date)
-                  );
-                }
-
-                componentsInfo.push(mapComponentDetails(result));
-                componentsReleases += result.allVersions.length;
-                callback();
-              }
-            ),
-          (err) => {
-            if (err) return next(err);
-
-            componentsInfo = componentsInfo.sort((a, b) =>
-              a.name.localeCompare(b.name)
-            );
-            res.send(
-              indexView(
-                // @ts-ignore
-                Object.assign(baseResponse, {
-                  availableDependencies: getAvailableDependencies(
-                    res.conf.dependencies
-                  ),
-                  availablePlugins: res.conf.plugins,
-                  components: componentsInfo,
-                  componentsReleases,
-                  componentsList: componentsInfo.map((component) => {
-                    const state: 'deprecated' | 'experimental' | '' =
-                      component?.oc?.state || '';
-                    if (state) {
-                      stateCounts[state] = (stateCounts[state] || 0) + 1;
-                    }
-
-                    return {
-                      name: component.name,
-                      author: component.author,
-                      state
-                    };
-                  }),
-                  q: req.query['q'] || '',
-                  stateCounts,
-                  templates: repository.getTemplatesInfo(),
-                  title: 'OpenComponents Registry'
-                })
-              )
+    if (isHtmlRequest(req.headers) && !!res.conf.discovery.ui) {
+      const componentsInfo: ParsedComponent[] = componentResults.map(
+        (result) => {
+          if (result.oc?.date) {
+            result.oc.stringifiedDate = dateStringified(
+              new Date(result.oc.date)
             );
           }
-        );
-      } else {
-        res.status(200).json(
+          return mapComponentDetails(result);
+        }
+      );
+
+      const componentsReleases = componentResults.reduce(
+        (sum, result) => sum + result.allVersions.length,
+        0
+      );
+
+      const stateCounts: { deprecated?: number; experimental?: number } = {};
+
+      const componentsList = componentsInfo.map((component) => {
+        const state: 'deprecated' | 'experimental' | '' =
+          (component?.oc?.state as 'deprecated' | 'experimental' | '') || '';
+        if (state) {
+          stateCounts[state] = (stateCounts[state] || 0) + 1;
+        }
+        return {
+          name: component.name,
+          author: component.author,
+          state
+        };
+      });
+
+      componentsInfo.sort((a, b) => a.name.localeCompare(b.name));
+
+      res.send(
+        indexView(
+          // @ts-ignore existing code relies on runtime merging
           Object.assign(baseResponse, {
-            components: components.map((component) =>
-              urlBuilder.component(component, res.conf.baseUrl)
-            )
+            availableDependencies: getAvailableDependencies(
+              res.conf.dependencies
+            ),
+            availablePlugins: res.conf.plugins,
+            components: componentsInfo,
+            componentsReleases,
+            componentsList,
+            q: req.query['q'] || '',
+            stateCounts,
+            templates: repository.getTemplatesInfo(),
+            title: 'OpenComponents Registry'
           })
+        )
+      );
+    } else {
+      const state = req.query['state'] || '';
+      let list = componentResults;
+      if (!res.conf.discovery.experimental) {
+        list = list.filter(
+          (component) => component.oc?.state !== 'experimental'
         );
       }
-    });
+      if (state) {
+        list = list.filter((component) => component.oc?.state === state);
+      }
+
+      res.status(200).json(
+        Object.assign(baseResponse, {
+          components: list.map((component) =>
+            urlBuilder.component(component.name, res.conf.baseUrl)
+          )
+        })
+      );
+    }
   };
 }

--- a/src/registry/routes/plugins.ts
+++ b/src/registry/routes/plugins.ts
@@ -3,7 +3,7 @@ import type { Config } from '../../types';
 
 export default function plugins(conf: Config) {
   return (_req: Request, res: Response): void => {
-    if (res.conf.discovery) {
+    if (res.conf.discovery.ui) {
       const plugins = Object.entries(conf.plugins).map(
         ([pluginName, pluginFn]) => ({
           name: pluginName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,11 +199,18 @@ export interface Config<T = any> {
    */
   dependencies: string[];
   /**
-   * Enables the HTML discovery page and `/components` endpoint.
-   *
-   * @default true
+   * Configuration object to enable/disable the HTML discovery page and the API
    */
-  discovery: boolean;
+  discovery: {
+    /**
+     * Enables the HTML discovery page
+     */
+    ui: boolean;
+    /**
+     * Shows experimental components from the API
+     */
+    experimental: boolean;
+  };
   /**
    * Function invoked to decide whether discovery should be enabled for the
    * current request.

--- a/test/unit/registry-routes-dependencies.js
+++ b/test/unit/registry-routes-dependencies.js
@@ -38,7 +38,7 @@ describe('registry : routes : plugins', () => {
       initialise();
       const conf = {
         dependencies: ['fs', 'undici'],
-        discovery: false
+        discovery: { ui: false }
       };
       dependenciesRoute = DependenciesRoute(conf);
 
@@ -55,7 +55,7 @@ describe('registry : routes : plugins', () => {
       initialise();
       const conf = {
         dependencies: ['fs', 'undici'],
-        discovery: true
+        discovery: { ui: true }
       };
       dependenciesRoute = DependenciesRoute(conf);
 

--- a/test/unit/registry-routes-plugins.js
+++ b/test/unit/registry-routes-plugins.js
@@ -43,7 +43,7 @@ describe('registry : routes : plugins', () => {
       initialise();
       const conf = {
         plugins,
-        discovery: true
+        discovery: { ui: true }
       };
       pluginsRoute = PluginsRoute(conf);
 


### PR DESCRIPTION
This provides a way to query components by state with a ?state query on the components endpoint, so you can get only experimental. And also extend the discovery option from boolean to object, so there's a new experimental boolean where you can completely hide them from being discovered even at the API level.