### PR TITLE
add publisher field

### DIFF
--- a/src/registry/domain/repository.ts
+++ b/src/registry/domain/repository.ts
@@ -373,6 +373,7 @@ export default function repository(conf: Config) {
       }
 
       pkgDetails.packageJson.oc.date = getUnixUtcTimestamp();
+      pkgDetails.packageJson.oc.publishedBy = user;
 
       if (dryRun) return;
 

--- a/src/registry/domain/repository.ts
+++ b/src/registry/domain/repository.ts
@@ -373,7 +373,7 @@ export default function repository(conf: Config) {
       }
 
       pkgDetails.packageJson.oc.date = getUnixUtcTimestamp();
-      pkgDetails.packageJson.oc.publishedBy = user;
+      pkgDetails.packageJson.oc.publisher = user;
 
       if (dryRun) return;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ interface OcConfiguration {
   renderInfo?: boolean;
   state?: 'deprecated' | 'experimental';
   stringifiedDate: string;
+  publishedBy?: string;
   version: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ interface OcConfiguration {
   renderInfo?: boolean;
   state?: 'deprecated' | 'experimental';
   stringifiedDate: string;
-  publishedBy?: string;
+  publisher?: string;
   version: string;
 }
 


### PR DESCRIPTION
Now that the registry allows for multiple logins, it makes sense to add as metadata the user who published a specific component.