### PR TITLE
hide log calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc",
-  "version": "0.50.14",
+  "version": "0.50.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc",
-      "version": "0.50.14",
+      "version": "0.50.17",
       "license": "MIT",
       "dependencies": {
         "@kitajs/html": "^4.2.9",
@@ -33,7 +33,7 @@
         "multer": "^1.4.3",
         "nice-cache": "^0.0.5",
         "oc-client": "^4.0.2",
-        "oc-client-browser": "^2.1.2",
+        "oc-client-browser": "^2.1.3",
         "oc-empty-response-handler": "^1.0.2",
         "oc-get-unix-utc-timestamp": "^1.0.6",
         "oc-s3-storage-adapter": "^2.2.0",
@@ -7396,9 +7396,9 @@
       }
     },
     "node_modules/oc-client-browser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-2.1.2.tgz",
-      "integrity": "sha512-x7YebwIf+sSe4feO8C4L0M0dszAAmYGh68HXN6G05WMS/ir3gGatEDBVemocu5EOl9rr6BKzDMA2t2ddeVwtmQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/oc-client-browser/-/oc-client-browser-2.1.3.tgz",
+      "integrity": "sha512-1Nq/WbdyLtpSUPNoeg1cwIKy4L1CIFoSGUWvNqMKDW7kN3ATsGVypim0+Z0ZC7jlhXJpP0jJw4gbh3De+JHmDA==",
       "license": "MIT",
       "dependencies": {
         "@rdevis/turbo-stream": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "multer": "^1.4.3",
     "nice-cache": "^0.0.5",
     "oc-client": "^4.0.2",
-    "oc-client-browser": "^2.1.2",
+    "oc-client-browser": "^2.1.3",
     "oc-empty-response-handler": "^1.0.2",
     "oc-get-unix-utc-timestamp": "^1.0.6",
     "oc-s3-storage-adapter": "^2.2.0",

--- a/src/registry/middleware/index.ts
+++ b/src/registry/middleware/index.ts
@@ -44,7 +44,17 @@ export const bind = (app: Express, options: Config): Express => {
   app.use(discoveryHandler);
 
   if (options.verbosity) {
-    app.use(morgan('dev'));
+    app.use(
+      morgan('dev', {
+        skip: (req) => {
+          // Hide logging development console calls
+          return (
+            req.method === 'POST' &&
+            req.url.startsWith('/~actions/$$__oc__server___console__$$')
+          );
+        }
+      })
+    );
   }
 
   if (options.local) {


### PR DESCRIPTION
For the new option in oc-server to send logs from the browser to the console, since they are performed through actions, this will hide those calls, since are noise in this case