### PR TITLE
fix fallback

### DIFF
--- a/src/registry/routes/helpers/get-component-fallback.ts
+++ b/src/registry/routes/helpers/get-component-fallback.ts
@@ -83,8 +83,8 @@ export function getComponent(
   component: { name: string; version: string; parameters: IncomingHttpHeaders },
   callback: (result: GetComponentResult) => void
 ): void {
-  // For some reason, undici doesn't like the content-type header
-  const { 'content-type': _, ...restHeaders } = headers;
+  // Avoid forwarding body/content negotiation headers that break fallback parsing.
+  const { 'content-type': _, 'accept-encoding': __, ...restHeaders } = headers;
   request(fallbackRegistryUrl, {
     method: 'POST',
     headers: {

--- a/test/unit/registry-routes-helpers-get-component-fallback.js
+++ b/test/unit/registry-routes-helpers-get-component-fallback.js
@@ -1,0 +1,54 @@
+const expect = require('chai').expect;
+const injectr = require('injectr');
+const sinon = require('sinon');
+
+describe('registry : routes : helpers : get-component-fallback', () => {
+  it('should not forward accept-encoding header when fetching from fallback registry', (done) => {
+    const requestStub = sinon.stub().resolves({
+      statusCode: 200,
+      body: {
+        json: sinon.stub().resolves([
+          {
+            status: 200,
+            response: { name: 'my-component' }
+          }
+        ])
+      }
+    });
+
+    const getComponentFallback = injectr(
+      '../../dist/registry/routes/helpers/get-component-fallback.js',
+      {
+        undici: {
+          request: requestStub
+        }
+      },
+      { URL }
+    );
+
+    getComponentFallback.getComponent(
+      'http://localhost:4000/',
+      {
+        'accept-encoding': 'gzip, deflate, br',
+        'content-type': 'application/json',
+        'x-custom-header': 'test-value'
+      },
+      { name: 'my-component', version: '1.0.0', parameters: {} },
+      (result) => {
+        expect(result).to.eql({
+          status: 200,
+          response: { name: 'my-component' }
+        });
+
+        const requestHeaders = requestStub.getCall(0).args[1].headers;
+
+        expect(requestHeaders['accept-encoding']).to.equal(undefined);
+        expect(requestHeaders['content-type']).to.equal(undefined);
+        expect(requestHeaders['Content-Type']).to.equal('application/json');
+        expect(requestHeaders['x-custom-header']).to.equal('test-value');
+
+        done();
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Fix fallback registry component fetches failing with:

`SyntaxError: Unexpected token '\u001f' ... is not valid JSON`

This happened when the fallback request forwarded `accept-encoding`, received a compressed response, and attempted to parse it as JSON.

## Root Cause
In `get-component-fallback`, the fallback `POST` request forwarded incoming headers (including `accept-encoding`) and then called `response.body.json()`.  
If the fallback registry returned gzip/brotli content, parsing failed.

## Changes
- Updated `src/registry/routes/helpers/get-component-fallback.ts`
  - Stop forwarding `accept-encoding` to fallback registry requests.
  - Keep existing `content-type` filtering.
  - Preserve forwarding of other headers.

## Tests
- Added `test/unit/registry-routes-helpers-get-component-fallback.js`
  - Verifies `accept-encoding` is not forwarded.
  - Verifies `content-type` is not forwarded as-is.
  - Verifies custom headers are still forwarded.
  - Verifies successful fallback response handling.

## Validation
- `npm run build` ✅
- `npx mocha test/unit/registry-routes-helpers-get-component-fallback.js` ✅

## Risk
Low. Change is scoped to fallback registry header forwarding in one helper.
