### PR TITLE
Registry UI: fix theming bugs and small UX polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "lint": "npx @biomejs/biome check preview src test tasks",
     "lint:apply": "npx @biomejs/biome check --write preview src test tasks",
+    "preview": "bun run preview/uiPreview.ts",
     "prebuild": "rimraf dist",
     "build": "npm run lint && tsc && node tasks/build.js",
     "git-stage-and-push": "node tasks/git-stage-and-push.js",

--- a/src/registry/views/partials/components-list.tsx
+++ b/src/registry/views/partials/components-list.tsx
@@ -100,12 +100,13 @@ const ComponentsList = (props: {
           <input
             id="search-filter"
             type="text"
-            autofocus
+            aria-label="Filter by component name"
             placeholder="Filter by component name"
           />
           <input
             id="author-filter"
             type="text"
+            aria-label="Filter by component author"
             placeholder="Filter by component author"
           />
         </div>

--- a/src/registry/views/static/index.ts
+++ b/src/registry/views/static/index.ts
@@ -4,12 +4,24 @@ var oc = oc || {};
 oc.cmd = oc.cmd || [];
 
 oc.cmd.push(function() {
+  var escapeRegExp = function(s) {
+    return String(s).replace(/[.*+?^\${}()|[\\]\\\\]/g, '\\\\$&');
+  };
+
+  var safeRegExp = function(pattern, flags) {
+    try {
+      return new RegExp(pattern, flags);
+    } catch (e) {
+      return new RegExp(escapeRegExp(pattern), flags);
+    }
+  };
+
   var componentsListChanged = function() {
     $('.componentRow').removeClass('hide');
     var s = $('#search-filter').val(),
       a = $('#author-filter').val(),
-      r = new RegExp(s),
-      ar = new RegExp(a, 'i'),
+      r = safeRegExp(s, ''),
+      ar = safeRegExp(a, 'i'),
       selectedCheckboxes = $('input[type=checkbox]:checked'),
       hiddenStates = [],
       hidden = 0,
@@ -163,7 +175,7 @@ oc.cmd.push(function() {
         historyContent.show();
         
         if (historyData.length === 0) {
-          historyContent.html('<p style="text-align: center; color: #64748b; padding: 2em;">No components history available.</p>');
+          historyContent.html('<p class="empty-state">No components history available.</p>');
           return;
         }
 
@@ -189,7 +201,14 @@ oc.cmd.push(function() {
       $target.show();
       $('#menuList a').removeClass('selected');
       $('#menuList a[href="' + target + '"]').addClass('selected');
-      
+
+      // Keep URL in sync so tab survives refresh and back/forward
+      try {
+        if (history && history.replaceState && location.hash !== target) {
+          history.replaceState(null, '', target);
+        }
+      } catch (e) {}
+
       // Clean up scroll listeners when leaving history tab
       if (target !== '#components-history') {
         $(window).off('scroll.history resize.history');
@@ -216,13 +235,28 @@ oc.cmd.push(function() {
     });
   };
 
+  var debounce = function(fn, wait) {
+    var t;
+    return function() {
+      var ctx = this, args = arguments;
+      clearTimeout(t);
+      t = setTimeout(function(){ fn.apply(ctx, args); }, wait);
+    };
+  };
+
   $('#filter-components')
     .submit(componentsListChanged)
-    .keyup(componentsListChanged);
+    .keyup(debounce(componentsListChanged, 80));
   $('#filter-components input[type=checkbox]').change(componentsListChanged);
 
   if (q) {
     $('.search').val(q);
+  }
+
+  // Focus the search input only on a fresh load (no tab hash, no in-page nav)
+  if (!location.hash) {
+    var $searchInput = $('#search-filter');
+    if ($searchInput.length) { $searchInput.focus(); }
   }
 
   componentsListChanged();

--- a/src/registry/views/static/style.ts
+++ b/src/registry/views/static/style.ts
@@ -205,7 +205,7 @@ body::before {
 }
 
 .theme-toggle:hover .theme-toggle-icon {
-  transform: rotate(180deg);
+  transform: rotate(15deg);
 }
 
 h1, h2, h3 {
@@ -417,14 +417,14 @@ p {
   font-size: 1.15rem;
   margin: 0;
   width: 100%;
-  color: var(--color-text-default);
+  color: var(--color-text-primary);
 }
 
 .componentRow .release {
   font-size: 1rem;
   margin: 0;
   width: 100%;
-  color: var(--color-text-default);
+  color: var(--color-text-primary);
 }
 
 .componentRow .title .description {
@@ -550,16 +550,12 @@ select:focus {
 }
 
 .filters input {
-  color: #0f0f23;
-  background-color: #eee;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-card);
 }
 
 #author-filter {
   flex: 0 1 30%;
-}
-
-@media (min-width: 1024px) {
-  margin-left: 15px;
 }
 
 .parameter {
@@ -576,7 +572,7 @@ select:focus {
 .author {
   flex: 0 1 15%;
   word-break: break-all;
-  color: var(--color-info);
+  color: var(--color-text-secondary);
 }
 
 #href {
@@ -862,7 +858,7 @@ a.tab-link.selected {
 }
 
 .info-item {
-  display: flow;
+  display: flex;
   align-items: start;
   padding: 0.75rem 0;
   border-bottom: 1px solid var(--color-border);
@@ -912,12 +908,12 @@ a.tab-link.selected {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--gradient-primary);
+  background: var(--color-border-hover);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--gradient-secondary);
+  background: var(--color-primary);
 }
 
 /* Main Content Layout */
@@ -1167,6 +1163,14 @@ a.tab-link.selected {
   color: var(--color-text-muted);
 }
 
+.empty-state {
+  text-align: center;
+  padding: 2em;
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin: 0;
+}
+
 .loader p {
   margin: 0;
   font-style: italic;
@@ -1387,17 +1391,17 @@ a.tab-link.selected {
 
 .stats-badge .chart-bar:nth-child(1) {
   height: 12px;
-  background: #10b981; /* green */
+  background: var(--color-primary-light);
 }
 
 .stats-badge .chart-bar:nth-child(2) {
   height: 16px;
-  background: #ef4444; /* red */
+  background: var(--color-primary);
 }
 
 .stats-badge .chart-bar:nth-child(3) {
   height: 20px;
-  background: #3b82f6; /* blue */
+  background: var(--color-primary-dark);
 }
 
 .stats-badge .badge-text {


### PR DESCRIPTION
## Summary

Small, low-risk UI/UX improvements to the registry web views and a new `npm run preview` script for previewing them locally. No interaction model changes.

## Bug fixes (`src/registry/views/static/style.ts`)

- Replace undefined `--color-text-default` with `--color-text-primary` on `.componentRow .title .name` and `.componentRow .release` (component name and version were silently falling back to inherited color).
- Replace undefined `--color-info` with `--color-text-secondary` on `.author`.
- `.filters input` no longer hard-codes `color: #0f0f23; background-color: #eee;` — filter inputs were broken in dark mode. Now uses the themed tokens.
- Remove stray, invalid `@media (min-width: 1024px) { margin-left: 15px; }` block with no selector inside.
- `.info-item` `display: flow` (not a valid CSS value) → `display: flex`, so the `align-items: start` actually applies on desktop.

## Aesthetic polish (same file)

- `.stats-badge` mini-chart bars now use three shades of brand indigo (`--color-primary-light/--color-primary/--color-primary-dark`) instead of unrelated green/red/blue.
- Theme-toggle icon hover rotation reduced from 180° to 15° (less distracting on incidental mouse-overs).
- Scrollbar thumb uses a flat `--color-border-hover` with `--color-primary` on hover, instead of the indigo→cyan gradient swap.
- New `.empty-state` class for themed empty-state messages.

## UX improvements

`src/registry/views/partials/components-list.tsx`
- Remove `autofocus` from the search input (it was stealing focus and scrolling on every navigation, including back/forward and mobile).
- Add `aria-label` to both filter inputs (placeholder-as-label is a common a11y issue).

`src/registry/views/static/index.ts`
- Wrap the search regex in a `safeRegExp` helper so invalid patterns (`[`, `c++`, etc.) no longer throw an uncaught `SyntaxError` and break filtering.
- Debounce the keyup handler at 80ms.
- Focus the search input on initial load only when there is no URL hash, so deep-linking to a tab doesn't yank focus.
- Tab clicks now call `history.replaceState`, so refresh and back/forward preserve the selected tab.
- History tab's empty state uses the new `.empty-state` class instead of inline `color: #64748b`.

## Tooling

- Add `npm run preview` → `bun run preview/uiPreview.ts`. Serves the mocked home and info views on http://localhost:4444 with auto-reload, using the existing `preview/uiPreview.ts` + `preview/fakeVM.ts`.

## Verification

Local checks against `npm run preview`:
- Home (`/`) and info (`/:name/:version/~info`) both return HTTP 200.
- All targeted regression patterns absent from rendered HTML: `--color-text-default`, `--color-info`, `display: flow`, `background-color: #eee`, `rotate(180deg)`, `new RegExp(s)`, inline `color: #64748b; padding: 2em`.
- All positive markers present: `empty-state`, `rotate(15deg)`, `aria-label="Filter by component …"`, `safeRegExp`, `history.replaceState`, `debounce(`.
- Light and dark themes both render cleanly; filter inputs now match the theme.

## Files changed

```
 package.json                                    |  1 +
 src/registry/views/partials/components-list.tsx |  3 +-
 src/registry/views/static/index.ts              | 44 +++++++++++++++++++---
 src/registry/views/static/style.ts              | 36 +++++++++--------
 4 files changed, 62 insertions(+), 22 deletions(-)
```