### PR TITLE
perf(get-component): cache acceptLanguageParser.parse results

### DIFF
--- a/packages/oc/src/registry/routes/helpers/get-component.ts
+++ b/packages/oc/src/registry/routes/helpers/get-component.ts
@@ -141,6 +141,14 @@ export default function getComponent(conf: Config, repository: Repository) {
   });
   const convertPlugins = pluginConverter(conf.plugins);
 
+  const parseAcceptLanguage = (header: string) => {
+    const cached = cache.get('accept-language', header);
+    if (cached) return cached;
+    const parsed = acceptLanguageParser.parse(header);
+    cache.set('accept-language', header, parsed);
+    return parsed;
+  };
+
   const getEnv = async (
     component: Component
   ): Promise<Record<string, string>> => {
@@ -588,7 +596,9 @@ export default function getComponent(conf: Config, repository: Repository) {
               emptyResponseHandler.contextDecorator(returnComponent);
             const contextObj = {
               action: options.action,
-              acceptLanguage: acceptLanguageParser.parse(acceptLanguage!),
+              acceptLanguage: acceptLanguage
+                ? parseAcceptLanguage(acceptLanguage)
+                : [],
               baseUrl: conf.baseUrl,
               env: { ...conf.env, ...env },
               params,

--- a/packages/oc/src/registry/routes/helpers/get-component.ts
+++ b/packages/oc/src/registry/routes/helpers/get-component.ts
@@ -143,7 +143,7 @@ export default function getComponent(conf: Config, repository: Repository) {
 
   const parseAcceptLanguage = (header: string) => {
     const cached = cache.get('accept-language', header);
-    if (cached) return cached;
+    if (cached !== undefined) return cached;
     const parsed = acceptLanguageParser.parse(header);
     cache.set('accept-language', header, parsed);
     return parsed;


### PR DESCRIPTION
acceptLanguageParser.parse is called on every data-provider request with
the same Accept-Language header value. Since it's a pure function (same
input → same output), cache the result using the existing nice-cache instance
keyed by the raw header string.

This avoids repeated parsing of identical Accept-Language headers across
concurrent and sequential requests from the same browser.
