### PR TITLE
fix: registry security and traversal vulnerabilities

### DIFF
--- a/packages/oc/src/registry/domain/repository.ts
+++ b/packages/oc/src/registry/domain/repository.ts
@@ -154,6 +154,12 @@ export default function repository(conf: Config) {
       componentName: string,
       componentVersion?: string
     ): Promise<Component> {
+      if (!validator.validateComponentName(componentName)) {
+        throw {
+          code: strings.errors.registry.COMPONENT_NAME_NOT_VALID_CODE,
+          msg: strings.errors.registry.COMPONENT_NAME_NOT_VALID
+        };
+      }
       const allVersions = await repository.getComponentVersions(componentName);
 
       if (allVersions.length === 0) {
@@ -179,7 +185,7 @@ export default function repository(conf: Config) {
       const component = await repository
         .getComponentInfo(componentName, version)
         .catch((err) => {
-          throw `component not available: ${errorToString(err)}`;
+          throw 'component not available';
         });
 
       return Object.assign(component, { allVersions });
@@ -188,6 +194,12 @@ export default function repository(conf: Config) {
       componentName: string,
       componentVersion: string
     ): Promise<Component> {
+      if (!validator.validateComponentName(componentName)) {
+        return Promise.reject({
+          code: strings.errors.registry.COMPONENT_NAME_NOT_VALID_CODE,
+          msg: strings.errors.registry.COMPONENT_NAME_NOT_VALID
+        });
+      }
       if (conf.local) {
         let componentInfo: Component;
 
@@ -253,6 +265,12 @@ export default function repository(conf: Config) {
       content: string;
       filePath: string;
     }> {
+      if (!validator.validateComponentName(componentName)) {
+        throw {
+          code: strings.errors.registry.COMPONENT_NAME_NOT_VALID_CODE,
+          msg: strings.errors.registry.COMPONENT_NAME_NOT_VALID
+        };
+      }
       if (conf.local) {
         return local.getDataProvider(componentName);
       }
@@ -271,6 +289,12 @@ export default function repository(conf: Config) {
       componentName: string,
       componentVersion: string
     ): Promise<Record<string, string>> {
+      if (!validator.validateComponentName(componentName)) {
+        return Promise.reject({
+          code: strings.errors.registry.COMPONENT_NAME_NOT_VALID_CODE,
+          msg: strings.errors.registry.COMPONENT_NAME_NOT_VALID
+        });
+      }
       if (conf.local) {
         return local.getEnv(componentName);
       }


### PR DESCRIPTION
1. Summary of changes: Added mandatory component name validation to all registry repository methods to prevent directory traversal attacks and refactored error handling in the `getComponent` method to avoid exposing detailed internal error information.

2. Rationale behind the implementation: The registry repository lacked validation for the `componentName` parameter in several functions (`getComponent`, `getComponentInfo`, `getDataProvider`, `getEnv`), which could allow for directory traversal attacks if a malicious component name was provided. Additionally, the original error handling in `getComponent` leaked internal error details via `errorToString(err)`, violating the security policy to only return generic error messages to API consumers.

3. Technical impact analysis: Improves the security posture of the registry by preventing unauthorized access to files outside the designated component directory and reducing the amount of sensitive internal information exposed in error scenarios.