### PR TITLE
Overhaul registry UI with cleaner design and UX improvements

### DIFF
--- a/packages/oc/src/registry/views/index.tsx
+++ b/packages/oc/src/registry/views/index.tsx
@@ -4,6 +4,7 @@ import History from './partials/components-history';
 import List from './partials/components-list';
 import Plugins from './partials/components-plugins';
 import Templates from './partials/components-templates';
+import Icon from './partials/icon';
 import Layout from './partials/layout';
 import indexJS from './static/index';
 
@@ -37,7 +38,9 @@ ${indexJS}</script>`;
             'experimental'
           )} experimental, ${getCount('deprecated')} deprecated`}
         >
-          <span aria-hidden="true">📦</span>
+          <span class="section-icon" aria-hidden="true">
+            <Icon name="box" size={16} />
+          </span>
           {vm.components.length} Components ({getCount('experimental')}{' '}
           experimental, {getCount('deprecated')} deprecated)
         </output>
@@ -89,7 +92,7 @@ ${indexJS}</script>`;
         <aside class="sidebar">
           <div class="info-card">
             <h3 class="section-title" style="margin-bottom: 1.5rem;">
-              📋 Registry Info
+              <Icon name="info" size={15} /> Registry Info
             </h3>
             <div class="info-item">
               <span class="info-label">Base URL</span>

--- a/packages/oc/src/registry/views/info.tsx
+++ b/packages/oc/src/registry/views/info.tsx
@@ -5,6 +5,7 @@ import ComponentAuthor from './partials/component-author';
 import ComponentParameters from './partials/component-parameters';
 import getComponentState from './partials/component-state';
 import ComponentVersions from './partials/component-versions';
+import Icon from './partials/icon';
 import Layout from './partials/layout';
 import infoJS from './static/info';
 
@@ -85,7 +86,7 @@ function statsJs(name: string, componentDetail: ComponentDetail) {
             display: true,
             position: 'top',
             labels: {
-              color: '#ffffff',
+              color: '#9aa4b2',
               font: {
                 family: 'Inter, -apple-system, BlinkMacSystemFont, sans-serif',
                 size: 14,
@@ -234,7 +235,9 @@ export default function Info(vm: Vm) {
     >
       <section class="hero">
         <nav class="breadcrumb">
-          <a href={href}>← All components</a>
+          <a href={href}>
+            <Icon name="arrow-left" size={14} /> All components
+          </a>
         </nav>
         <h1 class="component-title" safe>
           {component.name}
@@ -278,7 +281,9 @@ export default function Info(vm: Vm) {
                 class="section-header collapsible-header"
                 data-target="stats-content"
               >
-                <div class="section-icon">📈</div>
+                <div class="section-icon">
+                  <Icon name="chart" />
+                </div>
                 <h2 class="section-title">Package Size History</h2>
                 <button
                   type="button"
@@ -326,7 +331,9 @@ export default function Info(vm: Vm) {
           <section class="url-section">
             <div class="content-section">
               <div class="section-header">
-                <div class="section-icon">🔗</div>
+                <div class="section-icon">
+                  <Icon name="link" />
+                </div>
                 <h2 class="section-title">Component URL</h2>
               </div>
               <div class="section-content">
@@ -334,14 +341,23 @@ export default function Info(vm: Vm) {
                   You can edit the following area and then refresh or hit Enter
                   to apply the change into the preview window.
                 </p>
-                <input
-                  class="w-100"
-                  id="href"
-                  type="text"
-                  placeholder="Insert component href here"
-                  value={componentHref}
-                  style="width: 100%; font-family: 'Monaco', 'Menlo', monospace; font-size: 0.875rem; padding: 1rem 1.5rem; border-radius: 12px;"
-                />
+                <div class="url-input-group">
+                  <input
+                    class="w-100"
+                    id="href"
+                    type="text"
+                    placeholder="Insert component href here"
+                    value={componentHref}
+                  />
+                  <button
+                    type="button"
+                    class="btn btn-secondary copy-href"
+                    aria-label="Copy component URL"
+                  >
+                    <Icon name="link" size={15} />
+                    <span class="copy-href-label">Copy</span>
+                  </button>
+                </div>
                 <div class="field" style="margin-top: 1rem;">
                   <p>Accept-Language header:</p>
                   <input
@@ -361,10 +377,10 @@ export default function Info(vm: Vm) {
               <h2 class="section-title">Live Preview</h2>
               <div class="preview-buttons">
                 <button type="submit" class="btn btn-primary refresh-preview">
-                  🔄 Refresh
+                  <Icon name="refresh" size={15} /> Refresh
                 </button>
                 <button type="submit" class="btn btn-secondary open-preview">
-                  🚀 Open in New Tab
+                  <Icon name="external" size={15} /> Open in New Tab
                 </button>
               </div>
             </div>
@@ -380,7 +396,7 @@ export default function Info(vm: Vm) {
         <aside class="sidebar">
           <div class="info-card">
             <h3 class="section-title" style="margin-bottom: 1.5rem;">
-              📋 Component Info
+              <Icon name="info" size={15} /> Component Info
             </h3>
             <div class="info-item">
               <span class="info-label">Author</span>
@@ -425,7 +441,7 @@ export default function Info(vm: Vm) {
           {repositoryUrl ? (
             <div class="info-card">
               <h3 class="section-title" style="margin-bottom: 1.5rem;">
-                🔗 Links
+                <Icon name="link" size={15} /> Links
               </h3>
               <div class="info-item">
                 <span class="info-label">Repository</span>
@@ -440,7 +456,7 @@ export default function Info(vm: Vm) {
 
           <div class="info-card">
             <h3 class="section-title" style="margin-bottom: 1.5rem;">
-              📦 Dependencies
+              <Icon name="package" size={15} /> Dependencies
             </h3>
             <div class="info-item">
               <span class="info-label">Node.js</span>

--- a/packages/oc/src/registry/views/partials/component-parameters.tsx
+++ b/packages/oc/src/registry/views/partials/component-parameters.tsx
@@ -1,4 +1,5 @@
 import type { OcParameter } from '../../../types';
+import Icon from './icon';
 
 const componentParameters = ({
   parameters,
@@ -11,7 +12,9 @@ const componentParameters = ({
     return (
       <section class="content-section">
         <div class="section-header">
-          <div class="section-icon">⚙️</div>
+          <div class="section-icon">
+            <Icon name="settings" />
+          </div>
           <h2 class="section-title">Parameters</h2>
         </div>
         <div class="section-content">
@@ -116,7 +119,9 @@ const componentParameters = ({
         class="section-header collapsible-header"
         data-target="parameters-content"
       >
-        <div class="section-icon">⚙️</div>
+        <div class="section-icon">
+          <Icon name="settings" />
+        </div>
         <h2 class="section-title">Parameters</h2>
         <button
           type="button"

--- a/packages/oc/src/registry/views/partials/components-dependencies.tsx
+++ b/packages/oc/src/registry/views/partials/components-dependencies.tsx
@@ -26,7 +26,11 @@ const ComponentsDependencies = (props: {
 
   return (
     <div id="components-dependencies" class="box">
-      {props.availableDependencies.map(dependencyRow)}
+      {props.availableDependencies.length ? (
+        props.availableDependencies.map(dependencyRow)
+      ) : (
+        <div class="empty-state">No dependencies registered</div>
+      )}
     </div>
   );
 };

--- a/packages/oc/src/registry/views/partials/components-list.tsx
+++ b/packages/oc/src/registry/views/partials/components-list.tsx
@@ -101,7 +101,7 @@ const ComponentsList = (props: {
             id="search-filter"
             type="text"
             aria-label="Filter by component name"
-            placeholder="Filter by component name"
+            placeholder="Filter by name…  ( press / )"
           />
           <input
             id="author-filter"
@@ -119,8 +119,11 @@ const ComponentsList = (props: {
           />
         </div>
       </form>
+      <div class="list-meta">
+        <span id="results-count">{props.components.length} components</span>
+      </div>
       <div class="row header componentRow table">
-        <div class="title" />
+        <div class="title">Component</div>
         <div class="author">Author</div>
         <div>Latest version</div>
         {isRemote && (
@@ -132,6 +135,9 @@ const ComponentsList = (props: {
         {sizeAvailable && <div>Size</div>}
       </div>
       {props.components.map(componentRow)}
+      <div id="components-empty" class="empty-state hide">
+        No components match your filters.
+      </div>
     </div>
   );
 };

--- a/packages/oc/src/registry/views/partials/components-plugins.tsx
+++ b/packages/oc/src/registry/views/partials/components-plugins.tsx
@@ -17,7 +17,11 @@ const ComponentsPlugins = (props: {
 
   return (
     <div id="components-plugins" class="box">
-      {plugins.length ? plugins.map(pluginRow) : 'No plugins registered'}
+      {plugins.length ? (
+        plugins.map(pluginRow)
+      ) : (
+        <div class="empty-state">No plugins registered</div>
+      )}
     </div>
   );
 };

--- a/packages/oc/src/registry/views/partials/components-templates.tsx
+++ b/packages/oc/src/registry/views/partials/components-templates.tsx
@@ -12,12 +12,14 @@ const ComponentsTemplates = (props: { templates: Templates }) => {
     url: string;
   }) => (
     <a safe href={url} target="_blank" rel="noreferrer">
-      {global}
+      {Array.isArray(global) ? global.join(', ') : global}
     </a>
   );
 
   const templateRow = ({ externals, type, version }: Template) => {
-    const externalLinks = externals.map(externalLink);
+    const externalLinks = externals.flatMap((external, i) =>
+      i === 0 ? [externalLink(external)] : [', ', externalLink(external)]
+    );
     const externalsLabel = externalLinks.length ? (
       <> (Externals: {externalLinks}) </>
     ) : null;
@@ -41,7 +43,11 @@ const ComponentsTemplates = (props: { templates: Templates }) => {
 
   return (
     <div id="components-templates" class="box">
-      {props.templates.map(templateRow)}
+      {props.templates.length ? (
+        props.templates.map(templateRow)
+      ) : (
+        <div class="empty-state">No templates registered</div>
+      )}
     </div>
   );
 };

--- a/packages/oc/src/registry/views/partials/icon.tsx
+++ b/packages/oc/src/registry/views/partials/icon.tsx
@@ -1,0 +1,59 @@
+type IconName =
+  | 'box'
+  | 'clock'
+  | 'layers'
+  | 'package'
+  | 'plug'
+  | 'settings'
+  | 'link'
+  | 'chart'
+  | 'info'
+  | 'play'
+  | 'refresh'
+  | 'external'
+  | 'sun'
+  | 'moon'
+  | 'arrow-left';
+
+const paths: Record<IconName, string> = {
+  box: '<path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><polyline points="3.29 7 12 12 20.71 7"/><line x1="12" x2="12" y1="22" y2="12"/>',
+  clock: '<circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/>',
+  layers:
+    '<polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/>',
+  package:
+    '<path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><polyline points="3.29 7 12 12 20.71 7"/><line x1="12" x2="12" y1="22" y2="12"/>',
+  plug: '<path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/>',
+  settings:
+    '<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>',
+  link: '<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>',
+  chart:
+    '<line x1="12" x2="12" y1="20" y2="10"/><line x1="18" x2="18" y1="20" y2="4"/><line x1="6" x2="6" y1="20" y2="16"/>',
+  info: '<circle cx="12" cy="12" r="9"/><line x1="12" x2="12" y1="11" y2="16"/><line x1="12" x2="12.01" y1="8" y2="8"/>',
+  play: '<polygon points="6 3 20 12 6 21 6 3"/>',
+  refresh:
+    '<path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/>',
+  external:
+    '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
+  sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>',
+  moon: '<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>',
+  'arrow-left': '<path d="m12 19-7-7 7-7"/><path d="M19 12H5"/>'
+};
+
+const Icon = ({ name, size = 18 }: { name: IconName; size?: number }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={String(size)}
+    height={String(size)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    {paths[name]}
+  </svg>
+);
+
+export default Icon;

--- a/packages/oc/src/registry/views/partials/layout.tsx
+++ b/packages/oc/src/registry/views/partials/layout.tsx
@@ -23,7 +23,12 @@ const Layout = ({
     .replace('http://', '//')
     .replace('https://', '//');
 
-  const themeIcon = theme === 'light' ? '🌙' : '☀️';
+  const sunSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>';
+  const moonSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>';
+
+  const themeIcon = theme === 'light' ? moonSvg : sunSvg;
   const themeText = theme === 'light' ? 'Switch to Dark' : 'Switch to Light';
 
   return (
@@ -72,7 +77,7 @@ const Layout = ({
 
           <main class="container">{children}</main>
 
-          <div class="social">
+          <footer class="social container">
             <iframe
               id="gh_badge"
               title="GitHub"
@@ -81,12 +86,14 @@ const Layout = ({
               height="20"
               frameborder="0"
             />
-          </div>
+          </footer>
           <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js" />
           <script src={`${normalizedHref}oc-client/client.js`} />
           <script>{`
             // Theme switching functionality
             (function() {
+              const sunSvg = ${JSON.stringify(sunSvg)};
+              const moonSvg = ${JSON.stringify(moonSvg)};
               const themeToggle = document.getElementById('theme-toggle');
               const themeIcon = themeToggle.querySelector('.theme-toggle-icon');
               const themeText = themeToggle.querySelector('span:last-child');
@@ -112,10 +119,10 @@ const Layout = ({
               function applyTheme(theme) {
                 document.documentElement.setAttribute('data-theme', theme);
                 if (theme === 'light') {
-                  themeIcon.textContent = '🌙';
+                  themeIcon.innerHTML = moonSvg;
                   themeText.textContent = 'Switch to Dark';
                 } else {
-                  themeIcon.textContent = '☀️';
+                  themeIcon.innerHTML = sunSvg;
                   themeText.textContent = 'Switch to Light';
                 }
               }

--- a/packages/oc/src/registry/views/static/index.ts
+++ b/packages/oc/src/registry/views/static/index.ts
@@ -54,19 +54,20 @@ oc.cmd.push(function() {
     }
 
     var totalShowing = componentsList.length - hidden,
-      result = 'Showing ' + totalShowing + ' components';
+      result = totalShowing + (totalShowing === 1 ? ' component' : ' components');
 
     if (s) {
-      result += ' matching search query: "' + s + '"';
+      result += ' matching "' + s + '"';
       if (a) {
         result += ' and';
       }
     }
     if (a) {
-      result += ' matching author query: "' + a + '"';
+      result += ' by author "' + a + '"';
     }
 
-    $('.componentRow.header .title').text(result);
+    $('#results-count').text(result);
+    $('#components-empty')[totalShowing === 0 ? 'removeClass' : 'addClass']('hide');
 
     return false;
   };
@@ -252,6 +253,23 @@ oc.cmd.push(function() {
   if (q) {
     $('.search').val(q);
   }
+
+  // Keyboard shortcuts: "/" focuses search, "Esc" clears the focused filter
+  $(document).on('keydown', function(e) {
+    var tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : '';
+    var typing = tag === 'input' || tag === 'textarea' || tag === 'select';
+
+    if (e.key === '/' && !typing) {
+      var $s = $('#search-filter');
+      if ($s.length) {
+        e.preventDefault();
+        $s.focus();
+      }
+    } else if (e.key === 'Escape' && typing && $(e.target).closest('#filter-components').length) {
+      $(e.target).val('');
+      componentsListChanged();
+    }
+  });
 
   // Focus the search input only on a fresh load (no tab hash, no in-page nav)
   if (!location.hash) {

--- a/packages/oc/src/registry/views/static/info.ts
+++ b/packages/oc/src/registry/views/static/info.ts
@@ -101,6 +101,35 @@ oc.cmd.push(function() {
     return false;
   });
 
+  // Copy the component URL to the clipboard with inline feedback
+  $('.copy-href').click(function() {
+    var $btn = $(this);
+    var $label = $btn.find('.copy-href-label');
+    var value = $('#href').val();
+
+    var onDone = function() {
+      var prev = $label.text();
+      $label.text('Copied');
+      $btn.addClass('copied');
+      setTimeout(function() {
+        $label.text(prev || 'Copy');
+        $btn.removeClass('copied');
+      }, 1500);
+    };
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(value).then(onDone).catch(function() {
+        $('#href').select();
+        try { document.execCommand('copy'); onDone(); } catch (e) {}
+      });
+    } else {
+      $('#href').select();
+      try { document.execCommand('copy'); onDone(); } catch (e) {}
+    }
+
+    return false;
+  });
+
   // Collapsible sections functionality
   function initCollapsibleSections() {
     // Check if we're on mobile (screen width <= 1024px)

--- a/packages/oc/src/registry/views/static/style.ts
+++ b/packages/oc/src/registry/views/static/style.ts
@@ -1,76 +1,80 @@
 export default `
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 :root {
-  /* Primary brand colors (consistent across themes) */
+  /* Brand accent (consistent across themes) */
   --color-primary: #6366f1;
   --color-primary-dark: #4f46e5;
   --color-primary-light: #818cf8;
-  --color-secondary: #06b6d4;
-  --color-accent: #f59e0b;
+  --color-secondary: #0891b2;
+  --color-accent: #d97706;
 
   --gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-  --gradient-secondary: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
-  --gradient-accent: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
 
-  /* Legacy color mappings for backward compatibility */
-  --color-warning: #ffe066;
-  --color-warning-text: #7c3aed;
-  --color-danger: #ffd6d6;
-  --color-danger-text: #c92a2a;
-  --color-state-border: #e9ecef;
+  /* Spacing / radius scale */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-full: 999px;
+
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
 }
 
 /* Dark theme (default) */
 :root, [data-theme="dark"] {
-  --color-bg-primary: #0f0f23;
-  --color-bg-secondary: #1a1a2e;
-  --color-bg-card: #16213e;
-  --color-bg-glass: rgba(255, 255, 255, 0.05);
+  --color-bg-primary: #0b0e14;
+  --color-bg-secondary: #11151d;
+  --color-bg-card: #11151d;
+  --color-bg-elevated: #161c26;
+  --color-bg-glass: rgba(255, 255, 255, 0.04);
+  --color-bg-hover: rgba(255, 255, 255, 0.035);
 
-  --color-text-primary: #ffffff;
-  --color-text-secondary: #b4b4b8;
-  --color-text-muted: #acacb9;
+  --color-text-primary: #e6edf3;
+  --color-text-secondary: #aeb6c2;
+  --color-text-muted: #7d8693;
 
-  --color-border: rgba(255, 255, 255, 0.1);
-  --color-border-hover: rgba(255, 255, 255, 0.2);
+  --color-border: #222a37;
+  --color-border-hover: #323c4d;
 
-  --gradient-card: rgba(255,255,255,0.03); /* Simplified from gradient */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px -2px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 12px 28px -6px rgba(0, 0, 0, 0.5);
+  --shadow-glow: 0 4px 16px -2px rgba(99, 102, 241, 0.4);
 
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  --shadow-glow: 0 0 20px rgba(99, 102, 241, 0.3);
-
-  /* Dark theme text inverse (for buttons, etc) */
   --color-text-inverse: #ffffff;
+
+  --tint-strength: 0.16;
+  --tint-border: 0.32;
+  --badge-text-lightness: 78%;
 }
 
 /* Light theme */
 [data-theme="light"] {
-  --color-bg-primary: #ffffff;
-  --color-bg-secondary: #f8fafc;
+  --color-bg-primary: #fbfcfd;
+  --color-bg-secondary: #f4f6f8;
   --color-bg-card: #ffffff;
-  --color-bg-glass: rgba(255, 255, 255, 0.8);
+  --color-bg-elevated: #ffffff;
+  --color-bg-glass: rgba(255, 255, 255, 0.7);
+  --color-bg-hover: rgba(15, 23, 42, 0.025);
 
-  --color-text-primary: #1e293b;
-  --color-text-secondary: #475569;  /* Improved contrast from #64748b */
-  --color-text-muted: #64748b;      /* Improved contrast from #94a3b8 */
+  --color-text-primary: #1f2328;
+  --color-text-secondary: #4a535e;
+  --color-text-muted: #6a737d;
 
-  --color-border: rgba(0, 0, 0, 0.1);
-  --color-border-hover: rgba(0, 0, 0, 0.15);
+  --color-border: #e2e6ea;
+  --color-border-hover: #cdd3da;
 
-  --gradient-card: rgba(0,0,0,0.02); /* Simplified from gradient */
+  --shadow-sm: 0 1px 2px 0 rgba(15, 23, 42, 0.05);
+  --shadow-md: 0 4px 12px -2px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 12px 28px -6px rgba(15, 23, 42, 0.12);
+  --shadow-glow: 0 4px 16px -2px rgba(99, 102, 241, 0.25);
 
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  --shadow-glow: 0 0 20px rgba(99, 102, 241, 0.2);
-
-  /* Light theme text inverse (for buttons, etc) */
   --color-text-inverse: #ffffff;
+
+  --tint-strength: 0.1;
+  --tint-border: 0.28;
+  --badge-text-lightness: 38%;
 }
 
 * {
@@ -86,48 +90,27 @@ export default `
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-sans);
   background: var(--color-bg-primary);
   color: var(--color-text-primary);
   line-height: 1.6;
   min-height: 100vh;
   overflow-x: hidden;
-}
-
-/* Animated background - Dark theme */
-body::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background:
-    radial-gradient(circle at 20% 80%, rgba(99, 102, 241, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(139, 92, 246, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(6, 182, 212, 0.05) 0%, transparent 50%);
-  z-index: -1;
-  transition: opacity 0.3s ease;
-}
-
-/* Animated background - Light theme */
-[data-theme="light"] body::before {
-  background:
-    radial-gradient(circle at 20% 80%, rgba(99, 102, 241, 0.03) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(139, 92, 246, 0.03) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(6, 182, 212, 0.02) 0%, transparent 50%);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-size: 15px;
 }
 
 .container {
-  max-width: 1400px;
+  max-width: 1240px;
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 1.5rem;
 }
 
-/* Header */
+/* ── Header ─────────────────────────────────────────── */
 .header {
-  background: var(--color-bg-glass);
-  backdrop-filter: blur(20px);
+  background: color-mix(in srgb, var(--color-bg-primary) 80%, transparent);
+  backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 0;
@@ -138,102 +121,105 @@ body::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 0;
+  padding: 0.85rem 0;
 }
 
 .logo {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65rem;
   text-decoration: none;
   color: var(--color-text-primary);
-  font-weight: 700;
-  font-size: 1.25rem;
-  transition: all 0.3s ease;
+  font-weight: 600;
+  font-size: 1.0rem;
+  letter-spacing: -0.01em;
+  transition: color 0.15s ease;
+  margin-top: 0;
 }
 
 .logo:hover {
-  color: var(--color-primary-light);
-  transform: translateY(-1px);
+  color: var(--color-text-primary);
+  text-decoration: none;
 }
 
 .logo-icon {
   color: #fff;
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
   background: var(--gradient-primary);
   border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: bold;
-  font-size: 1.1rem;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  box-shadow: var(--shadow-sm);
 }
 
 .logo img {
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
   border-radius: 8px;
 }
 
 /* Theme Toggle Button */
 .theme-toggle {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: var(--color-bg-glass);
+  padding: 0.45rem 0.85rem;
+  background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: 8px;
-  color: var(--color-text-primary);
-  font-size: 0.875rem;
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
   font-weight: 500;
-  transition: all 0.3s ease;
+  font-family: inherit;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
   cursor: pointer;
-  backdrop-filter: blur(10px);
 }
 
 .theme-toggle:hover {
   border-color: var(--color-border-hover);
-  background: var(--color-bg-card);
-  transform: translateY(-1px);
+  color: var(--color-text-primary);
+  background: var(--color-bg-elevated);
 }
 
 .theme-toggle-icon {
-  font-size: 1.1rem;
-  transition: transform 0.3s ease;
+  font-size: 1rem;
+  line-height: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary);
 }
 
-.theme-toggle:hover .theme-toggle-icon {
-  transform: rotate(15deg);
-}
+.theme-toggle:hover .theme-toggle-icon { color: var(--color-text-primary); }
+.theme-toggle-icon svg { display: block; }
 
+/* ── Typography ─────────────────────────────────────── */
 h1, h2, h3 {
   color: var(--color-text-primary);
   font-weight: 600;
-  margin-bottom: 0.5em;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.4em;
 }
 
 h1 {
-  font-size: 3.5rem;
-  font-weight: 700;
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin-bottom: 1rem;
-  text-align: center;
+  font-size: 2rem;
+  font-weight: 680;
+  margin-bottom: 0.5rem;
+  line-height: 1.2;
 }
 
 h2 {
-  font-size: 1.5rem;      /* Increased from 1.25rem */
+  font-size: 1.2rem;
   font-weight: 600;
-  color: var(--color-text-primary);
-  margin-bottom: 0.75em;
 }
 
 h3 {
-  font-size: 1.25rem;     /* Increased from 1.1rem */
+  font-size: 1.05rem;
   font-weight: 600;
 }
 
@@ -242,301 +228,384 @@ h3 {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
-
-*:focus:not(:focus-visible) {
-  outline: none;
-}
-
+*:focus:not(:focus-visible) { outline: none; }
 *:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
 a {
-  color: var(--color-text-primary);
+  color: var(--color-primary-light);
   text-decoration: none;
-  transition: color 0.3s ease;
-  border-radius: 4px; /* For better focus outline */
+  transition: color 0.15s ease;
+  border-radius: 4px;
 }
-a:hover {
-  color: var(--color-primary);
-  text-decoration: underline;
-}
-a:focus {
-  color: var(--color-primary);
-}
+a:hover { color: var(--color-primary); text-decoration: underline; }
+a:focus { color: var(--color-primary); }
 
-#components-list a:hover {
-  text-decoration: none;
-}
+[data-theme="light"] a { color: var(--color-primary-dark); }
 
-p {
-  margin-top: 0;
-}
+#components-list a:hover { text-decoration: none; }
 
-.logo {
-  margin-top: 10px;
-}
+p { margin-top: 0; }
 
 .back {
   width: 100%;
-  margin-top: -20px;
   margin-bottom: 1.5em;
   display: block;
   color: var(--color-text-muted);
-  font-size: 0.95em;
+  font-size: 0.9em;
 }
 
-/* Content Sections */
+/* ── Hero ───────────────────────────────────────────── */
+.hero {
+  padding: 2.5rem 0 1.5rem;
+  position: relative;
+}
+
+.hero h1 { text-align: left; }
+
+.component-title {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 1.85rem;
+  letter-spacing: -0.01em;
+}
+
+.component-description {
+  color: var(--color-text-secondary);
+  max-width: 70ch;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.version-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0.75rem 0;
+}
+
+.version-label {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+/* ── Stats badge ────────────────────────────────────── */
+.stats-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.5rem 0.9rem;
+  margin: 1rem 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  font-weight: 500;
+  max-width: fit-content;
+}
+
+.stats-badge .chart-icon {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 16px;
+}
+
+.stats-badge .chart-bar { width: 3px; border-radius: 2px; }
+.stats-badge .chart-bar:nth-child(1) { height: 8px; background: var(--color-primary-light); }
+.stats-badge .chart-bar:nth-child(2) { height: 12px; background: var(--color-primary); }
+.stats-badge .chart-bar:nth-child(3) { height: 16px; background: var(--color-primary-dark); }
+
+.stats-badge .badge-text {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  font-weight: 500;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* ── Main layout ────────────────────────────────────── */
+.main-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 1.75rem;
+  padding: 1rem 0 3rem;
+  align-items: start;
+}
+
+.sidebar {
+  display: grid;
+  gap: 1.25rem;
+  align-content: start;
+  position: sticky;
+  top: 5rem;
+}
+
+/* ── Tabs ───────────────────────────────────────────── */
+#menuList {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 1.5rem !important;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+#menuList::-webkit-scrollbar { display: none; height: 0; }
+
+a.tab-link {
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  display: inline-block;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  white-space: nowrap;
+}
+
+a.tab-link:hover {
+  color: var(--color-text-primary);
+  background: transparent;
+  text-decoration: none;
+}
+
+a.tab-link.selected {
+  color: var(--color-primary-light);
+  background: transparent;
+  text-decoration: none;
+  border-bottom-color: var(--color-primary);
+}
+
+[data-theme="light"] a.tab-link.selected { color: var(--color-primary-dark); }
+
+/* ── Cards / sections ───────────────────────────────── */
 .content-section {
   background: var(--color-bg-card);
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
   overflow: hidden;
-  transition: all 0.3s ease;
-  margin-bottom: 2rem;
-}
-
-.content-section:hover {
-  border-color: var(--color-border-hover);
-  box-shadow: var(--shadow-lg);
+  margin-bottom: 1.5rem;
 }
 
 .section-header {
-  padding: 1.5rem 2rem;
-  background: var(--gradient-card);
+  padding: 1rem 1.5rem;
+  background: var(--color-bg-glass);
   border-bottom: 1px solid var(--color-border);
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.7rem;
 }
 
 .section-title {
-  font-size: 1.25rem;
+  font-size: 1.05rem;
   font-weight: 600;
   color: var(--color-text-primary);
+  letter-spacing: -0.01em;
 }
 
 .section-icon {
-  font-size: 1.25rem;
-  /* Removed gradient background, border-radius, and container styling */
-  /* Now just using emoji directly for better accessibility */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-primary-light);
+  flex-shrink: 0;
 }
 
-.section-content {
-  padding: 2rem;
-}
+.section-icon svg { width: 18px; height: 18px; display: block; }
 
-.code,
-.preview {
-  width: 100%;
+[data-theme="light"] .section-icon { color: var(--color-primary); }
+
+.section-content { padding: 1.5rem; }
+
+.box {
   background: var(--color-bg-card);
-  border-radius: 16px;
-  box-shadow: var(--shadow-md);
-  margin-bottom: 1.5em;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
+  padding: 1.25rem;
+  margin-bottom: 1.5em;
 }
 
-.preview {
-  height: 500px;
+/* ── Info cards (sidebar) ───────────────────────────── */
+.info-card {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem 1.35rem;
 }
 
-.preview iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
-  background: white;
-  border-radius: 0 0 16px 16px;
+.info-card .section-title {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  margin-bottom: 1rem !important;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.table {
-  width: 100%;
+.info-card .section-title svg { width: 15px; height: 15px; color: var(--color-text-muted); }
+
+.info-item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.875rem;
 }
 
-.w-100 {
-  width: 100%;
+.info-item:last-child { border-bottom: none; padding-bottom: 0; }
+.info-item:first-of-type { padding-top: 0; }
+
+.info-label {
+  font-weight: 500;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.info-value {
+  color: var(--color-text-primary);
+  text-align: right;
+  word-break: break-word;
+  font-weight: 450;
+}
+
+.info-value a { word-break: break-all; }
+
+/* ── List / table rows ──────────────────────────────── */
+#components-list.box,
+#components-history.box,
+#components-templates.box,
+#components-dependencies.box,
+#components-plugins.box {
+  padding: 0;
+  overflow: hidden;
 }
 
 .row {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0;
   width: 100%;
   display: flex;
-  padding: 14px 0px;
+  padding: 0.9rem 1.25rem;
   box-sizing: border-box;
-  margin-bottom: 8px;
+  margin-bottom: 0;
   align-items: center;
-  box-shadow: var(--shadow-md);
-  transition: all 0.3s ease;
+  box-shadow: none;
+  transition: background 0.12s ease;
+  gap: 0.5rem;
 }
+
+.row:last-child { border-bottom: none; }
 
 .row.header {
-  background: var(--gradient-card);
-  border: 1px solid var(--color-border) !important;
-  font-size: 1.1em;
-  font-weight: 600;
-  border-radius: 12px 12px 0 0;
-  box-shadow: none;
-  color: var(--color-text-primary);
-}
-
-.row.header div {
-  font-weight: bold;
-  margin: 0;
-  align-self: flex-start;
-}
-
-.row.double {
-  min-height: 60px;
-}
-
-.row div {
-  word-wrap: break-word;
-}
-
-.row span {
-  padding-right: 10px;
-}
-
-.componentRow {
-  transition:
-    box-shadow 0.2s,
-    background 0.2s;
-}
-
-.componentRow:hover {
   background: var(--color-bg-glass);
-  box-shadow: var(--shadow-lg);
-  border-color: var(--color-primary);
-  transform: translateY(-2px);
-}
-
-.componentRow .title .name {
-  font-weight: bold;
-  font-size: 1.15rem;
-  margin: 0;
-  width: 100%;
-  color: var(--color-text-primary);
-}
-
-.componentRow .release {
-  font-size: 1rem;
-  margin: 0;
-  width: 100%;
-  color: var(--color-text-primary);
-}
-
-.componentRow .title .description {
-  padding: 0;
-  font-size: 0.98rem;
+  border: none;
+  border-bottom: 1px solid var(--color-border) !important;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-radius: 0;
+  box-shadow: none;
   color: var(--color-text-muted);
 }
 
-.social {
-  width: 100%;
-  margin-top: 20px;
-  text-align: center;
-}
-
-.field {
-  width: 100%;
-  margin-bottom: 1em;
-}
-
-.field p,
-.field span,
-.field a {
+.row.header div {
+  font-weight: 600;
   margin: 0;
-  font-weight: 500;
-}
-
-.field p {
-  color: var(--color-primary);
-  font-weight: bold;
-  margin-right: 10px;
-}
-
-input[type="text"],
-textarea,
-select {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-primary);
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-  font-family: inherit;
-  font-size: 1rem;
-  transition: all 0.3s ease;
-  margin-bottom: 10px;
-  box-sizing: border-box;
-}
-
-input[type="text"]:focus,
-textarea:focus,
-select:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  border-radius: 8px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  text-decoration: none;
-  transition: all 0.3s ease;
-  border: none;
-  cursor: pointer;
-  font-family: inherit;
-}
-
-.btn-primary {
-  background: var(--gradient-primary);
-  color: white;
-}
-
-.btn-primary:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-glow);
-}
-
-.btn-secondary {
-  background: var(--color-bg-glass);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
-}
-
-.btn-secondary:hover {
-  border-color: var(--color-border-hover);
-  background: var(--color-bg-secondary);
-}
-
-.filters {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  gap: 1em;
-  margin-bottom: 0.5em;
-}
-
-.row > * {
-  flex: 0 1 8%;
-  padding: 0px 5px;
   align-self: center;
 }
 
-.row > *:last-child {
-  padding-right: 10px;
+.row.double { min-height: 56px; }
+.row div { word-wrap: break-word; }
+.row span { padding-right: 10px; }
+
+/* clickable component rows (anchors that wrap an entire row) */
+#components-list > a,
+#components-history a,
+#components-dependencies > a {
+  display: block;
+  color: inherit;
 }
 
-.row > *:first-child {
-  padding-left: 10px;
+.componentRow { transition: background 0.12s ease; }
+
+.componentRow:hover {
+  background: var(--color-bg-hover);
+  box-shadow: none;
+  border-color: var(--color-border);
+  transform: none;
 }
+
+#components-list > a:focus-visible,
+#components-history a:focus-visible,
+#components-dependencies > a:focus-visible {
+  outline: none;
+}
+
+#components-list > a:focus-visible .componentRow,
+#components-history a:focus-visible .componentRow,
+#components-dependencies > a:focus-visible .componentRow {
+  background: var(--color-bg-hover);
+  box-shadow: inset 2px 0 0 var(--color-primary);
+}
+
+.componentRow .title .name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin: 0;
+  width: 100%;
+  color: var(--color-text-primary);
+  letter-spacing: -0.005em;
+}
+
+.componentRow:hover .title .name { color: var(--color-primary-light); }
+[data-theme="light"] .componentRow:hover .title .name { color: var(--color-primary-dark); }
+
+.componentRow .release {
+  font-size: 0.9rem;
+  margin: 0;
+  width: 100%;
+  color: var(--color-text-secondary);
+}
+
+.componentRow .release a { color: var(--color-primary-light); }
+[data-theme="light"] .componentRow .release a { color: var(--color-primary-dark); }
+
+.componentRow .title .description {
+  padding: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-top: 0.15rem;
+  line-height: 1.45;
+}
+
+.row > * {
+  flex: 0 1 9%;
+  padding: 0 0.35rem;
+  align-self: center;
+  font-size: 0.875rem;
+}
+
+.row > *:last-child { padding-right: 0; }
+.row > *:first-child { padding-left: 0; }
 
 .release,
 .title,
@@ -547,69 +616,204 @@ select:focus {
 .title {
   display: flex;
   flex-direction: column;
-}
-
-.filters input {
-  color: var(--color-text-primary);
-  background-color: var(--color-bg-card);
-}
-
-#author-filter {
-  flex: 0 1 30%;
-}
-
-.parameter {
-  flex: 1 0;
-  max-width: 25%;
-  align-self: flex-start;
-}
-
-.parameter-description {
-  flex: 1 0;
-  max-width: 70%;
+  gap: 0.1rem;
 }
 
 .author {
   flex: 0 1 15%;
-  word-break: break-all;
+  word-break: break-word;
   color: var(--color-text-secondary);
+  font-size: 0.85rem;
 }
 
-#href {
-  height: 60px;
+.date { color: var(--color-text-muted); font-size: 0.85rem; }
+.activity { color: var(--color-text-secondary); font-size: 0.85rem; }
+
+/* ── Filters ────────────────────────────────────────── */
+.filters {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 1.25rem 1.25rem 0.75rem;
 }
+
+.filters input {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-secondary);
+  margin-bottom: 0;
+}
+
+#author-filter { flex: 0 1 30%; }
 
 .states {
   width: 100%;
-  margin-bottom: 30px;
+  margin: 0;
+  padding: 0 1.25rem 1.25rem;
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.25rem;
   flex-wrap: wrap;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .states > span {
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 0.8rem;
 }
 
-.states input {
-  margin-right: 6px;
+.states input { margin-right: 6px; }
+
+/* ── List results meta bar ──────────────────────────── */
+.list-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1.25rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  font-weight: 500;
 }
 
-/* Custom Checkbox Styling */
+#results-count { color: var(--color-text-secondary); }
+
+/* ── Component URL copy group ───────────────────────── */
+.url-input-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.url-input-group #href {
+  flex: 1;
+  margin-bottom: 0;
+  padding: 0.7rem 0.9rem;
+}
+
+.url-input-group .copy-href {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.copy-href.copied {
+  color: color-mix(in srgb, #10b981 70%, var(--color-text-primary));
+  border-color: color-mix(in srgb, #10b981 var(--tint-border), transparent);
+  background: color-mix(in srgb, #10b981 var(--tint-strength), transparent);
+}
+
+/* ── Forms ──────────────────────────────────────────── */
+input[type="text"],
+input[type="number"],
+textarea,
+select {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  padding: 0.6rem 0.85rem;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: 0.9rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+}
+
+input[type="text"]:focus,
+input[type="number"]:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 18%, transparent);
+}
+
+input::placeholder { color: var(--color-text-muted); }
+
+select {
+  cursor: pointer;
+  padding-right: 2rem;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%237d8693' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.7rem center;
+}
+
+#versions { margin-left: 0; min-width: 160px; margin-bottom: 0; }
+
+.w-100 { width: 100%; }
+.table { width: 100%; }
+
+/* ── Buttons ────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: all 0.15s ease;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.2;
+}
+
+.btn-primary { background: var(--color-primary); color: #fff; }
+.btn-primary:hover {
+  background: var(--color-primary-dark);
+  color: #fff;
+  text-decoration: none;
+  box-shadow: var(--shadow-glow);
+}
+
+.btn-secondary {
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+}
+.btn-secondary:hover {
+  border-color: var(--color-border-hover);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+/* ── Fields ─────────────────────────────────────────── */
+.field { width: 100%; margin-bottom: 1em; }
+
+.field p,
+.field span,
+.field a {
+  margin: 0;
+  font-weight: 500;
+}
+
+.field p {
+  color: var(--color-text-muted);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.4rem;
+}
+
+#href {
+  height: auto;
+  font-family: var(--font-mono) !important;
+  font-size: 0.825rem !important;
+}
+
+/* ── Checkbox ───────────────────────────────────────── */
 .checkbox-wrapper {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   cursor: pointer;
   user-select: none;
-  transition: all 0.3s ease;
-}
-
-.checkbox-wrapper:hover {
-  transform: translateY(-1px);
 }
 
 .checkbox-input {
@@ -620,12 +824,12 @@ select:focus {
 
 .checkbox-custom {
   position: relative;
-  width: 20px;
-  height: 20px;
-  background: var(--color-bg-card);
-  border: 2px solid var(--color-border);
-  border-radius: 6px;
-  transition: all 0.3s ease;
+  width: 18px;
+  height: 18px;
+  background: var(--color-bg-secondary);
+  border: 1.5px solid var(--color-border-hover);
+  border-radius: 5px;
+  transition: all 0.15s ease;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -633,27 +837,26 @@ select:focus {
 }
 
 .checkbox-input:checked + .checkbox-custom {
-  background: var(--gradient-primary);
+  background: var(--color-primary);
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
 }
 
-.checkbox-input:focus + .checkbox-custom {
+.checkbox-input:focus-visible + .checkbox-custom {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
 .checkbox-icon {
-  width: 12px;
-  height: 12px;
-  stroke: white;
-  stroke-width: 2;
+  width: 11px;
+  height: 11px;
+  stroke: #fff;
+  stroke-width: 2.5;
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
   opacity: 0;
-  transform: scale(0.8);
-  transition: all 0.2s ease;
+  transform: scale(0.7);
+  transition: all 0.15s ease;
 }
 
 .checkbox-input:checked + .checkbox-custom .checkbox-icon {
@@ -661,404 +864,338 @@ select:focus {
   transform: scale(1);
 }
 
-.checkbox-wrapper:hover .checkbox-custom {
-  border-color: var(--color-border-hover);
-  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.15);
-}
+.checkbox-wrapper:hover .checkbox-custom { border-color: var(--color-primary-light); }
 
-.checkbox-wrapper:hover .checkbox-input:checked + .checkbox-custom {
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2), 0 2px 8px rgba(99, 102, 241, 0.3);
-}
-
-/* Removed old details-state styling - now using state-badge class */
-
-#versions {
-  margin-left: 10px;
-}
-
-/* Updated state styling to use modern badge design */
-.state {
-  display: inline-flex;
-  align-items: center;
-  font-size: 0.875rem;
-  font-weight: 600;
-  padding: 0.375rem 0.75rem;
-  border-radius: 12px;
-  white-space: nowrap;
-  transition: all 0.3s ease;
-  border: 1px solid transparent;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  margin-right: 10px;
-}
-
-.table .state {
-  /* Remove the old background and height - now using component-state classes */
-}
-
-/* Enhanced State Badge Styling - moved to component state section */
-
-/* Component State Badge Styling */
+/* ── State badges ───────────────────────────────────── */
+.state,
 .state-badge {
   display: inline-flex;
   align-items: center;
-  font-size: 0.875rem;
+  font-size: 0.72rem;
   font-weight: 600;
-  padding: 0.375rem 0.75rem;
-  border-radius: 12px;
+  padding: 0.18rem 0.55rem;
+  border-radius: var(--radius-full);
   white-space: nowrap;
-  transition: all 0.3s ease;
+  transition: none;
   border: 1px solid transparent;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  margin-left: 0.75rem;
+  box-shadow: none;
+  text-transform: capitalize;
+  letter-spacing: 0.01em;
+  line-height: 1.4;
 }
 
-/* Mobile compact view - hidden on desktop */
-.mobile-compact {
-  display: none;
-}
+.state-badge { margin-left: 0.6rem; }
+.state { margin-right: 0; }
 
-.state-badge:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
+.state-badge:hover { transform: none; box-shadow: none; }
 
-/* Experimental state - warm orange/yellow like in the image */
+.mobile-compact { display: none; }
+
+/* Tinted, flat state badges (per-state hue) */
 .component-state-experimental {
-  background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
-  color: #92400e;
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.2);
+  background: color-mix(in srgb, #f59e0b var(--tint-strength), transparent);
+  color: color-mix(in srgb, #f59e0b var(--badge-text-lightness), var(--color-text-primary));
+  border-color: color-mix(in srgb, #f59e0b var(--tint-border), transparent);
 }
-
-.component-state-experimental:hover {
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
-}
-
-/* Deprecated state - red */
 .component-state-deprecated {
-  background: linear-gradient(135deg, #f87171 0%, #ef4444 100%);
-  color: #991b1b;
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.2);
+  background: color-mix(in srgb, #ef4444 var(--tint-strength), transparent);
+  color: color-mix(in srgb, #ef4444 var(--badge-text-lightness), var(--color-text-primary));
+  border-color: color-mix(in srgb, #ef4444 var(--tint-border), transparent);
 }
-
-.component-state-deprecated:hover {
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
-}
-
-/* Stable state - green */
 .component-state-stable {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  color: #064e3b;
-  border: 1px solid rgba(16, 185, 129, 0.3);
-  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.2);
+  background: color-mix(in srgb, #10b981 var(--tint-strength), transparent);
+  color: color-mix(in srgb, #10b981 var(--badge-text-lightness), var(--color-text-primary));
+  border-color: color-mix(in srgb, #10b981 var(--tint-border), transparent);
 }
-
-.component-state-stable:hover {
-  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
-}
-
-/* Beta state - blue */
 .component-state-beta {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: #1e3a8a;
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.2);
+  background: color-mix(in srgb, #3b82f6 var(--tint-strength), transparent);
+  color: color-mix(in srgb, #3b82f6 var(--badge-text-lightness), var(--color-text-primary));
+  border-color: color-mix(in srgb, #3b82f6 var(--tint-border), transparent);
 }
-
-.component-state-beta:hover {
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-}
-
-/* Alpha state - purple */
 .component-state-alpha {
-  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
-  color: #4c1d95;
-  border: 1px solid rgba(139, 92, 246, 0.3);
-  box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);
+  background: color-mix(in srgb, #8b5cf6 var(--tint-strength), transparent);
+  color: color-mix(in srgb, #8b5cf6 var(--badge-text-lightness), var(--color-text-primary));
+  border-color: color-mix(in srgb, #8b5cf6 var(--tint-border), transparent);
 }
 
-.component-state-alpha:hover {
-  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
-}
+.bold { font-weight: 600; }
+.hide { display: none !important; }
 
-a.tab-link {
-  color: var(--color-primary-light);
-  font-weight: 500;
-  padding: 0.5rem 1rem;
-  border-radius: 8px;
-  transition: all 0.3s ease;
-  font-size: 1rem;
-  line-height: 1.2;
-  vertical-align: middle;
-  display: inline-block;
-  border: 1px solid transparent;
-}
-
-a.tab-link:hover {
-  background: var(--color-bg-glass);
-  border-color: var(--color-border);
-}
-
-a.tab-link.selected {
-  background: var(--gradient-primary);
-  color: white;
-  text-decoration: none;
-  border-color: var(--color-primary);
-}
-
-.bold {
-  font-weight: bold;
-}
-
-.hide {
-  display: none !important;
-}
-
-.box {
-  background: var(--color-bg-card);
-  border-radius: 12px; /* Reduced from 16px */
-  border: 1px solid var(--color-border);
-  padding: 1.5em 2em;
-  margin-bottom: 2em;
-  transition: all 0.3s ease;
-  /* Removed default shadow */
-}
-
-.box:hover {
-  border-color: var(--color-border-hover);
-  box-shadow: var(--shadow-md); /* Only on hover */
-  transform: translateY(-1px); /* Reduced from -2px */
-}
-
-/* Hero Section */
-.hero {
-  padding: 3rem 0;
-  text-align: center;
-  position: relative;
-}
-
-/* Info Cards */
-.info-card {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 12px; /* Reduced from 16px */
-  padding: 1.5rem;
-  transition: all 0.3s ease;
-  margin-bottom: 1.5rem;
-  /* Removed default shadow */
-}
-
-.info-card:hover {
-  border-color: var(--color-border-hover);
-  transform: translateY(-1px); /* Reduced from -2px */
-  box-shadow: var(--shadow-md); /* Reduced from shadow-lg */
-}
-
-.info-item {
+/* ── Breadcrumb ─────────────────────────────────────── */
+.breadcrumb {
   display: flex;
-  align-items: start;
-  padding: 0.75rem 0;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.info-item:last-child {
-  border-bottom: none;
-}
-
-.info-label {
-  font-weight: 500;
+  align-items: center;
+  gap: 0.5rem;
   color: var(--color-text-secondary);
-  min-width: 100px;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
 }
 
-.info-value {
-  color: var(--color-text-primary);
-  text-align: right;
-  flex: 1;
-  margin-left: 1rem;
-}
+.breadcrumb a { color: var(--color-text-muted); font-weight: 500; }
+.breadcrumb a:hover { color: var(--color-primary); text-decoration: none; }
 
-/* Animations */
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
+/* ── Parameters ─────────────────────────────────────── */
+.parameter-grid { display: grid; gap: 1rem; }
 
-@keyframes float {
-  0%, 100% { transform: translateY(0px); }
-  50% { transform: translateY(-10px); }
-}
-
-/* Custom scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
-}
-
-::-webkit-scrollbar-track {
+.parameter-item {
   background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.1rem 1.25rem;
+  transition: border-color 0.15s ease;
 }
 
-::-webkit-scrollbar-thumb {
-  background: var(--color-border-hover);
-  border-radius: 4px;
+.parameter-item:hover { border-color: var(--color-border-hover); box-shadow: none; }
+
+.parameter-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.65rem;
+  flex-wrap: wrap;
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-primary);
+.parameter-name {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
 }
 
-/* Main Content Layout */
-.main-content {
-  display: grid;
-  grid-template-columns: 1fr 350px;
-  gap: 2rem;
-  padding: 2rem 0;
+.parameter-type {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  padding: 0.12rem 0.5rem;
+  border-radius: var(--radius-full);
+  font-size: 0.7rem;
+  font-weight: 500;
 }
 
-.sidebar {
-  display: grid;
-  gap: 1.5rem;
-  align-content: start;
+.parameter-required {
+  background: color-mix(in srgb, var(--color-accent) var(--tint-strength), transparent);
+  color: color-mix(in srgb, var(--color-accent) var(--badge-text-lightness), var(--color-text-primary));
+  border-color: color-mix(in srgb, var(--color-accent) var(--tint-border), transparent);
 }
 
-/* Collapsible Sections */
-.collapsible-section {
-  transition: all 0.3s ease;
+.parameter-description {
+  color: var(--color-text-secondary);
+  margin-bottom: 0.65rem;
+  line-height: 1.5;
+  font-size: 0.875rem;
 }
 
+.parameter-description strong { color: var(--color-text-primary); font-weight: 600; }
+
+.parameter-input {
+  width: 100%;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  padding: 0.55rem 0.8rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  margin-bottom: 0;
+}
+
+.parameter-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 18%, transparent);
+}
+
+/* ── Preview ────────────────────────────────────────── */
+.preview-section {
+  background: var(--color-bg-card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+  margin-top: 1.5rem;
+}
+
+.preview-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.5rem;
+  background: var(--color-bg-glass);
+  border-bottom: 1px solid var(--color-border);
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.preview-buttons { display: flex; gap: 0.6rem; }
+
+.preview-iframe,
+.preview iframe {
+  width: 100%;
+  height: 500px;
+  border: none;
+  background: #fff;
+  display: block;
+}
+
+.code,
+.preview {
+  width: 100%;
+  background: var(--color-bg-card);
+  border-radius: var(--radius-lg);
+  box-shadow: none;
+  margin-bottom: 1.5em;
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+}
+
+.preview { height: 500px; }
+
+/* ── Collapsible ────────────────────────────────────── */
 .collapsible-header {
   cursor: pointer;
   user-select: none;
   position: relative;
-  transition: all 0.3s ease;
+  transition: background 0.15s ease;
 }
 
-.collapsible-header:hover {
-  background: var(--color-bg-glass);
-}
+.collapsible-header:hover { background: var(--color-bg-hover); }
 
 .collapse-toggle {
   position: absolute;
-  right: 1.5rem;
+  right: 1.25rem;
   top: 50%;
   transform: translateY(-50%);
   background: none;
   border: none;
-  color: var(--color-text-secondary);
-  font-size: 1rem;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
   cursor: pointer;
-  padding: 0.5rem;
-  border-radius: 4px;
-  transition: all 0.3s ease;
+  padding: 0.4rem;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s ease, background 0.15s ease;
 }
 
-.collapse-toggle:hover {
-  background: var(--color-bg-glass);
-  color: var(--color-text-primary);
+.collapse-toggle:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
+
+.collapse-icon { transition: transform 0.2s ease; display: inline-block; }
+
+.collapsible-content { overflow: hidden; transition: all 0.25s ease; }
+
+.collapsible-content.collapsed { max-height: 0; padding-top: 0; padding-bottom: 0; opacity: 0; }
+.collapsible-content.expanded { max-height: 2000px; opacity: 1; }
+
+.collapsible-header.collapsed .collapse-icon { transform: rotate(-90deg); }
+
+/* ── Loading / empty / error ────────────────────────── */
+.loader { text-align: center; padding: 2em; color: var(--color-text-muted); }
+
+.empty-state {
+  text-align: center;
+  padding: 2.5em 2em;
+  color: var(--color-text-muted);
+  margin: 0;
 }
 
-.collapse-icon {
-  transition: transform 0.3s ease;
+.loader p { margin: 0; }
+
+.loader::before {
+  content: '';
   display: inline-block;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--color-border);
+  border-top: 2px solid var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-right: 0.6em;
+  vertical-align: middle;
 }
 
-.collapsible-content {
-  overflow: hidden;
-  transition: all 0.3s ease;
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.loading-more {
+  text-align: center;
+  padding: 1em 2em;
+  color: var(--color-text-muted);
+  font-size: 0.85em;
+  border-top: 1px solid var(--color-border);
 }
 
-.collapsible-content.collapsed {
-  max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  opacity: 0;
+.loading-more::before {
+  content: '';
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-border);
+  border-top: 2px solid var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-right: 0.5em;
+  vertical-align: middle;
 }
 
-.collapsible-content.expanded {
-  max-height: 2000px;
-  opacity: 1;
+#history-error {
+  text-align: center;
+  padding: 1.5em 2em;
+  color: color-mix(in srgb, #ef4444 70%, var(--color-text-primary));
+  background-color: color-mix(in srgb, #ef4444 var(--tint-strength), transparent);
+  border: 1px solid color-mix(in srgb, #ef4444 var(--tint-border), transparent);
+  border-radius: var(--radius-md);
+  margin: 1em;
 }
 
-.collapsible-header.collapsed .collapse-icon {
-  transform: rotate(-90deg);
+#history-error p { margin: 0; }
+
+/* ── Footer ─────────────────────────────────────────── */
+.social {
+  width: 100%;
+  margin-top: 0;
+  padding: 2rem 0 2.5rem;
+  text-align: center;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
 }
 
-/* Responsive */
+/* ── Scrollbar ──────────────────────────────────────── */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-border-hover); border-radius: 5px; border: 2px solid var(--color-bg-primary); }
+::-webkit-scrollbar-thumb:hover { background: var(--color-text-muted); }
+
+/* ── Animations ─────────────────────────────────────── */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Responsive ─────────────────────────────────────── */
 @media (max-width: 1024px) {
-
-  .info-item {
-    display: flex;
-    justify-content: space-between;
-  }
-
-  .container {
-    padding: 0 1rem;
-  }
-
-  h1 {
-    font-size: 2.5rem;
-  }
-
-  .main-content {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-  }
-
-  .sidebar {
-    order: -1;
-  }
-
-  /* Mobile collapsible sections - collapsed by default */
-  .collapsible-content {
-    max-height: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    opacity: 0;
-  }
-
-  .collapsible-header.collapsed .collapse-icon {
-    transform: rotate(-90deg);
-  }
+  .container { padding: 0 1.25rem; }
+  h1 { font-size: 1.75rem; }
+  .main-content { grid-template-columns: 1fr; gap: 1.25rem; }
+  .sidebar { order: -1; position: static; }
+  .info-item { display: flex; justify-content: space-between; }
+  .collapsible-content { max-height: 0; padding-top: 0; padding-bottom: 0; opacity: 0; }
+  .collapsible-header.collapsed .collapse-icon { transform: rotate(-90deg); }
 }
 
 @media (max-width: 900px) {
-  .container {
-    padding: 0 1rem;
-  }
+  .container { padding: 0 1rem; }
+  .main-content { padding: 0.5rem 0 2rem; gap: 1rem; }
+  .filters { flex-direction: column; gap: 0.5em; }
+  #author-filter { flex: 1 0; }
 
-  .main-content {
-    padding: 1rem 0;
-    gap: 1rem;
-  }
-
-  .filters {
-    flex-direction: column;
-    gap: 0.5em;
-  }
-
-  /* Mobile responsive components list */
-  .row.header {
-    display: none; /* Hide desktop table header on mobile */
-  }
+  .row.header { display: none; }
 
   .componentRow {
     flex-direction: column !important;
-    align-items: center !important;
-    padding: 1rem !important;
-    gap: 0.75rem !important;
-    text-align: center !important;
+    align-items: flex-start !important;
+    padding: 1rem 1.25rem !important;
+    gap: 0.6rem !important;
+    text-align: left !important;
   }
 
-  /* Hide desktop table columns on mobile */
   .componentRow > .author,
   .componentRow > .date,
   .componentRow > .activity,
@@ -1066,348 +1203,48 @@ a.tab-link.selected {
     display: none !important;
   }
 
-  /* Show mobile compact view */
-  .mobile-compact {
-    display: block !important;
-    width: 100%;
-  }
+  .mobile-compact { display: block !important; width: 100%; }
 
   .mobile-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.5rem;
     align-items: center;
-    justify-content: center;
-    font-size: 0.875rem;
+    font-size: 0.8rem;
     color: var(--color-text-secondary);
     width: 100%;
   }
 
   .mobile-meta span {
-    background: var(--color-bg-glass);
-    padding: 0.25rem 0.5rem;
-    border-radius: 6px;
+    background: var(--color-bg-secondary);
+    padding: 0.2rem 0.5rem;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--color-border);
-    font-size: 0.8rem;
+    font-size: 0.75rem;
     font-weight: 500;
   }
 
-  .mobile-author {
-    color: var(--color-primary) !important;
-  }
+  .mobile-author { color: var(--color-text-secondary) !important; }
+  .mobile-version { color: var(--color-text-primary) !important; font-weight: 600; }
+  .mobile-date { color: var(--color-text-muted) !important; }
+  .mobile-activity { color: var(--color-text-secondary) !important; }
+  .mobile-size { color: var(--color-text-secondary) !important; }
 
-  .mobile-version {
-    color: var(--color-text-primary) !important;
-    font-weight: 600;
-  }
+  .componentRow .title { text-align: left !important; width: 100%; }
+  .componentRow .title .name { text-align: left !important; }
+  .componentRow .title .description { text-align: left !important; }
 
-  .mobile-date {
-    color: var(--color-text-muted) !important;
-  }
+  .box, .info-card, .section-content { }
+  .section-content { padding: 1.25rem; }
 
-  .mobile-activity {
-    color: var(--color-accent) !important;
-  }
+  .sidebar .info-item { flex-direction: column; align-items: flex-start; gap: 0.3rem; }
+  .sidebar .info-label { min-width: auto; font-weight: 600; }
+  .sidebar .info-value { text-align: left; margin-left: 0; }
 
-  .mobile-size {
-    color: var(--color-secondary) !important;
-  }
-
-  /* Center the title section on mobile */
-  .componentRow .title {
-    text-align: center !important;
-    width: 100%;
-  }
-
-  .componentRow .title .name {
-    text-align: center !important;
-  }
-
-  .componentRow .title .description {
-    text-align: center !important;
-  }
-
-  .box, .info-card, .section-content {
-    padding: 1.5rem 1rem;
-  }
-
-  .sidebar .info-card {
-    padding: 1rem;
-  }
-
-  .sidebar .info-item {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .sidebar .info-label {
-    min-width: auto;
-    font-weight: 600;
-  }
-
-  .sidebar .info-value {
-    text-align: left;
-    margin-left: 0;
-  }
-
-  h1 {
-    font-size: 2rem;
-  }
-}
-
-/* Loading states */
-.loader {
-  text-align: center;
-  padding: 2em;
-  color: var(--color-text-muted);
-}
-
-.empty-state {
-  text-align: center;
-  padding: 2em;
-  color: var(--color-text-muted);
-  font-style: italic;
-  margin: 0;
-}
-
-.loader p {
-  margin: 0;
-  font-style: italic;
-}
-
-.loader::before {
-  content: '';
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--color-border);
-  border-top: 2px solid var(--color-primary);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin-right: 0.5em;
-  vertical-align: middle;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
-.loading-more {
-  text-align: center;
-  padding: 1em 2em;
-  color: var(--color-text-muted);
-  font-style: italic;
-  font-size: 0.9em;
-  border-top: 1px solid var(--color-border);
-  margin-top: 1em;
-}
-
-.loading-more::before {
-  content: '';
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--color-border);
-  border-top: 2px solid var(--color-primary);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin-right: 0.5em;
-  vertical-align: middle;
-}
-
-#history-error {
-  text-align: center;
-  padding: 2em;
-  color: var(--color-danger-text);
-  background-color: var(--color-danger);
-  border: 1px solid var(--color-state-border);
-  border-radius: 6px;
-  margin: 1em 0;
-}
-
-#history-error p {
-  margin: 0;
-}
-
-/* Breadcrumb */
-.breadcrumb {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--color-text-secondary);
-  font-size: 0.875rem;
-}
-
-.breadcrumb a {
-  color: var(--color-primary-light);
-  text-decoration: none;
-  transition: color 0.3s ease;
-}
-
-.breadcrumb a:hover {
-  color: var(--color-primary);
-}
-
-/* Parameters */
-.parameter-grid {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.parameter-item {
-  background: var(--color-bg-glass);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 1.5rem;
-  transition: all 0.3s ease;
-}
-
-.parameter-item:hover {
-  border-color: var(--color-primary);
-  box-shadow: 0 0 20px rgba(99, 102, 241, 0.1);
-}
-
-.parameter-header {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.parameter-name {
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.parameter-type {
-  background: var(--color-secondary);
-  color: white;
-  padding: 0.25rem 0.75rem;
-  border-radius: 12px; /* Reduced from 20px */
-  font-size: 0.75rem;
-  font-weight: 500;
-}
-
-.parameter-required {
-  background: var(--color-accent);
-}
-
-.parameter-description {
-  color: var(--color-text-secondary);
-  margin-bottom: 1rem;
-  line-height: 1.5;
-}
-
-.parameter-input {
-  width: 100%;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-primary);
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-  font-family: inherit;
-  transition: all 0.3s ease;
-}
-
-.parameter-input:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
-}
-
-/* Preview Section */
-.preview-section {
-  background: var(--color-bg-card);
-  border-radius: 16px;
-  border: 1px solid var(--color-border);
-  overflow: hidden;
-  margin-top: 2rem;
-}
-
-.preview-controls {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 2rem;
-  background: var(--color-bg-glass);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.preview-buttons {
-  display: flex;
-  gap: 0.75rem;
-}
-
-.preview-iframe {
-  width: 100%;
-  height: 500px;
-  border: none;
-  background: white;
-}
-
-.back {
-  width: 100%;
-  margin-top: -20px;
-  margin-bottom: 1.5em;
-  display: block;
-  color: var(--color-text-muted);
-  font-size: 0.95em;
-}
-
-/* Stats Badge */
-.stats-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 0.75rem 1.25rem;
-  margin: 1.5rem auto 0;
-  box-shadow: var(--shadow-md);
-  transition: all 0.3s ease;
-  max-width: fit-content;
-}
-
-.stats-badge:hover {
-  border-color: var(--color-border-hover);
-  box-shadow: var(--shadow-lg);
-  transform: translateY(-1px);
-}
-
-.stats-badge .chart-icon {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-}
-
-.stats-badge .chart-bar {
-  width: 4px;
-  border-radius: 2px;
-  background: var(--gradient-primary);
-}
-
-.stats-badge .chart-bar:nth-child(1) {
-  height: 12px;
-  background: var(--color-primary-light);
-}
-
-.stats-badge .chart-bar:nth-child(2) {
-  height: 16px;
-  background: var(--color-primary);
-}
-
-.stats-badge .chart-bar:nth-child(3) {
-  height: 20px;
-  background: var(--color-primary-dark);
-}
-
-.stats-badge .badge-text {
-  color: var(--color-text-primary);
-  font-size: 0.875rem;
-  font-weight: 500;
-  white-space: nowrap;
+  h1 { font-size: 1.6rem; }
+  .component-title { font-size: 1.5rem; }
+  .preview-controls { flex-direction: column; align-items: stretch; }
+  .preview-buttons { justify-content: stretch; }
+  .preview-buttons .btn { flex: 1; justify-content: center; }
 }
   `;


### PR DESCRIPTION
Complete visual overhaul of the OC registry UI, preserving all routes and JS interaction hooks.

**Visual**: Calmer developer-tool palette (GitHub-inspired dark/light), refined spacing/typography, underline-tab bar, integrated bordered card list, flat tinted state/param badges.

**Icons**: Inline SVG icon component replacing every emoji (section headers, buttons, breadcrumb arrow, theme toggle).

**UX**: Dedicated results bar (no more clobbered column header), empty states for all tabs, slash+Esc keyboard shortcuts, Copy URL button on component detail page, proper keyboard focus styling.

**Fixes**: Scrollbar hidden on tab bar, externals in Templates tab now comma-separated, chart legend color works in light theme, block display on template/deps external links corrected.

<img width="1645" height="1001" alt="image" src="https://github.com/user-attachments/assets/23dcdf30-5d67-4d7e-b6dd-59edf02f5f84" />
