### PR TITLE
Clean publish temp files after upload

### DIFF
--- a/packages/oc/src/registry/domain/extract-package.ts
+++ b/packages/oc/src/registry/domain/extract-package.ts
@@ -15,6 +15,8 @@ export default async function extractPackage(
 ): Promise<{
   outputFolder: string;
   packageJson: Component;
+  packagePath: string;
+  packageUntarOutput: string;
 }> {
   const packageFile = (files as Express.Multer.File[])[0];
   const packagePath = path.resolve(packageFile.path);
@@ -40,6 +42,8 @@ export default async function extractPackage(
 
   return {
     outputFolder: packageOutput,
-    packageJson
+    packageJson,
+    packagePath,
+    packageUntarOutput
   };
 }

--- a/packages/oc/src/registry/routes/publish.ts
+++ b/packages/oc/src/registry/routes/publish.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import fs from 'fs-extra';
 import strings from '../../resources/index';
 import eventsHandler from '../domain/events-handler';
 import extractPackage from '../domain/extract-package';
@@ -123,6 +124,11 @@ export default function publish(repository: Repository) {
           res.errorDetails = `Publish failed: ${errorMessage}`;
           res.status(500).json({ error: err });
         }
+      } finally {
+        await Promise.allSettled([
+          fs.remove(pkgDetails.packagePath),
+          fs.remove(pkgDetails.packageUntarOutput)
+        ]);
       }
     } catch (err) {
       res.errorDetails = `Package is not valid: ${err}`;

--- a/packages/oc/test/unit/registry-domain-extract-package.js
+++ b/packages/oc/test/unit/registry-domain-extract-package.js
@@ -63,7 +63,9 @@ describe('registry : domain : extract-package', () => {
     it('should respond', () => {
       expect(response).to.eql({
         outputFolder: '/some-path/registry/temp/1478279453422/_package/',
-        packageJson: { package: 'hello' }
+        packageJson: { package: 'hello' },
+        packagePath: '/some-path/registry/temp/1478279453422.tar.gz',
+        packageUntarOutput: '/some-path/registry/temp/1478279453422/'
       });
     });
   });

--- a/packages/oc/test/unit/registry-routes-publish.js
+++ b/packages/oc/test/unit/registry-routes-publish.js
@@ -1,0 +1,91 @@
+const fs = require('fs-extra');
+const os = require('node:os');
+const path = require('node:path');
+const expect = require('chai').expect;
+const injectr = require('injectr');
+const sinon = require('sinon');
+
+describe('registry : routes : publish', () => {
+  describe('when publish finishes', () => {
+    let packagePath;
+    let packageUntarOutput;
+    let tempDir;
+    let pkgDetails;
+    let publishRoute;
+    let repository;
+    let statusStub;
+
+    beforeEach(async () => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-publish-'));
+      packagePath = path.join(tempDir, '1478279453422.tar.gz');
+      packageUntarOutput = path.join(tempDir, '1478279453422');
+      fs.writeFileSync(packagePath, 'package');
+      fs.ensureDirSync(packageUntarOutput);
+      fs.writeFileSync(path.join(packageUntarOutput, 'kept-outside.txt'), 'file');
+
+      pkgDetails = {
+        outputFolder: path.join(packageUntarOutput, '_package'),
+        packageJson: {
+          oc: {
+            files: {
+              template: {}
+            }
+          }
+        },
+        packagePath,
+        packageUntarOutput
+      };
+      repository = {
+        publishComponent: sinon.stub().resolves()
+      };
+      statusStub = sinon.stub().returns({ json: sinon.stub() });
+
+      publishRoute = injectr(
+        '../../dist/registry/routes/publish.js',
+        {
+          '../domain/extract-package': {
+            __esModule: true,
+            default: sinon.stub().resolves(pkgDetails)
+          },
+          '../domain/validators': {
+            validatePackage: sinon.stub().returns({
+              isValid: true,
+              files: [{ path: packagePath }]
+            }),
+            validateOcCliVersion: sinon.stub().returns({ isValid: true }),
+            validateNodeVersion: sinon.stub().returns({ isValid: true }),
+            validateTemplateOcVersion: sinon.stub().returns({ isValid: true })
+          }
+        },
+        { process }
+      ).default(repository);
+
+      await publishRoute(
+        {
+          files: [{ path: packagePath }],
+          headers: {},
+          params: {
+            componentName: 'hello-world',
+            componentVersion: '1.0.0'
+          },
+          query: {}
+        },
+        {
+          conf: {
+            tarExtractMode: 766
+          },
+          status: statusStub
+        }
+      );
+    });
+
+    afterEach(() => {
+      fs.removeSync(tempDir);
+    });
+
+    it('should remove only the uploaded package and extracted package folder', () => {
+      expect(fs.existsSync(packagePath)).to.be.false;
+      expect(fs.existsSync(packageUntarOutput)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track the uploaded package tarball and extracted temp directory during registry publish
- Remove only the current upload's tarball and extracted directory after publishing finishes
- Add unit coverage for publish cleanup behavior

#### Test plan
- [x] npm --prefix packages/oc run build
- [x] npx --prefix packages/oc mocha packages/oc/test/unit/registry-domain-extract-package.js packages/oc/test/unit/registry-routes-publish.js

Generated with [Devin](https://devin.ai)