### PR TITLE
Force HTTP/1.1 for publish upload to avoid h2 premature close

### DIFF
--- a/packages/oc/src/utils/put.ts
+++ b/packages/oc/src/utils/put.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 import FormData from 'form-data';
 import fs from 'fs-extra';
-import { request } from 'undici';
+import { Agent, request } from 'undici';
+
+// undici v8 enables HTTP/2 by default when the TLS server negotiates it via
+// ALPN. Some gateways/proxies reset large multipart uploads over h2, surfacing
+// as "Premature close". Force HTTP/1.1 for the publish upload to avoid this.
+const dispatcher = new Agent({ allowH2: false });
 
 async function put(
   urlPath: string,
@@ -22,7 +27,8 @@ async function put(
   const res = await request(urlPath, {
     headers: { ...headers, ...form.getHeaders() },
     method: 'PUT',
-    body: form
+    body: form,
+    dispatcher
   });
 
   const response = await res.body.text();


### PR DESCRIPTION
undici v8 enables HTTP/2 by default when the TLS server negotiates it via ALPN. Some gateways/proxies reset large multipart uploads over h2, surfacing as a "Premature close" error. This change forces HTTP/1.1 for the publish upload request to avoid the issue.