### PR TITLE
Send publish credentials on first request

### DIFF
--- a/packages/oc/src/cli/facade/publish.ts
+++ b/packages/oc/src/cli/facade/publish.ts
@@ -172,7 +172,10 @@ const publish = ({
 
           await putComponentToRegistry({
             route: componentRoute,
-            path: compressedPackagePath
+            path: compressedPackagePath,
+            username: opts.username,
+            password: opts.password,
+            token: opts.token
           });
         }
         await local.cleanup(compressedPackagePath);

--- a/packages/oc/test/unit/cli-facade-publish.js
+++ b/packages/oc/test/unit/cli-facade-publish.js
@@ -190,6 +190,30 @@ describe('cli : facade : publish', () => {
                 });
               });
 
+              it('should pass supplied credentials on the first publish attempt', (done) => {
+                const putComponentStub = sinon
+                  .stub(registry, 'putComponent')
+                  .resolves('ok');
+
+                execute(
+                  () => {
+                    registry.putComponent.restore();
+
+                    expect(putComponentStub.args[0][0]).to.include({
+                      username: 'myuser',
+                      password: 'password'
+                    });
+                    done();
+                  },
+                  {
+                    creds: {
+                      username: 'myuser',
+                      password: 'password'
+                    }
+                  }
+                );
+              });
+
               describe('when a generic error happens', () => {
                 beforeEach((done) => {
                   sinon
@@ -322,8 +346,13 @@ describe('cli : facade : publish', () => {
                 });
 
                 it('should not prompt for credentials', () => {
-                  expect(logSpy.ok.args[0][0]).to.equal(
-                    'Using specified credentials'
+                  expect(
+                    logSpy.warn.args.some(
+                      (args) => args[0] === 'Registry requires credentials.'
+                    )
+                  ).to.equal(false);
+                  expect(logSpy.err.args[0][0]).to.equal(
+                    'An error happened when publishing the component: Invalid credentials'
                   );
                 });
               });


### PR DESCRIPTION
## Summary
- Pass supplied publish credentials into the first registry PUT request
- Avoid an initial unauthenticated 401 when users provide username/password or token
- Update publish facade tests for first-attempt credentials and invalid credential handling

#### Test plan
- [x] npm --prefix /Users/Ricardo.Agullo/Work/oc/packages/oc run build
- [x] cd /Users/Ricardo.Agullo/Work/oc/packages/oc && npx mocha test/unit/cli-facade-publish.js

Generated with [Devin](https://devin.ai)