### PR TITLE
Add client-side pagination to registry components tab

### DIFF
--- a/packages/oc/src/registry/views/partials/components-list.tsx
+++ b/packages/oc/src/registry/views/partials/components-list.tsx
@@ -122,6 +122,11 @@ const ComponentsList = (props: {
       <div class="list-meta">
         <span id="results-count">{props.components.length} components</span>
       </div>
+      <nav
+        id="components-pagination-top"
+        class="pagination components-pagination pagination-top hide"
+        aria-label="Components pagination"
+      />
       <div class="row header componentRow table">
         <div class="title">Component</div>
         <div class="author">Author</div>
@@ -139,8 +144,8 @@ const ComponentsList = (props: {
         No components match your filters.
       </div>
       <nav
-        id="components-pagination"
-        class="pagination hide"
+        id="components-pagination-bottom"
+        class="pagination components-pagination hide"
         aria-label="Components pagination"
       />
     </div>

--- a/packages/oc/src/registry/views/partials/components-list.tsx
+++ b/packages/oc/src/registry/views/partials/components-list.tsx
@@ -138,6 +138,11 @@ const ComponentsList = (props: {
       <div id="components-empty" class="empty-state hide">
         No components match your filters.
       </div>
+      <nav
+        id="components-pagination"
+        class="pagination hide"
+        aria-label="Components pagination"
+      />
     </div>
   );
 };

--- a/packages/oc/src/registry/views/static/index.ts
+++ b/packages/oc/src/registry/views/static/index.ts
@@ -16,28 +16,91 @@ oc.cmd.push(function() {
     }
   };
 
-  var componentsListChanged = function() {
-    $('.componentRow').removeClass('hide');
+  // Client-side pagination for the components list. Enabled only once the
+  // registry has more components than a single page so smaller registries keep
+  // the simple single-page view.
+  var COMPONENTS_PAGE_SIZE = 50;
+  var paginationEnabled = componentsList.length > COMPONENTS_PAGE_SIZE;
+  var currentPage = 1;
+
+  var renderComponentsPagination = function(totalMatching, totalPages) {
+    var container = $('#components-pagination');
+    if (!paginationEnabled || totalMatching <= COMPONENTS_PAGE_SIZE) {
+      container.addClass('hide').empty();
+      return;
+    }
+
+    // Build a compact list of page numbers: first, last, and a window around
+    // the current page, with ellipses for the gaps.
+    var pages = [];
+    var windowSize = 1;
+    var start = Math.max(2, currentPage - windowSize);
+    var end = Math.min(totalPages - 1, currentPage + windowSize);
+    pages.push(1);
+    if (start > 2) {
+      pages.push('...');
+    }
+    for (var p = start; p <= end; p++) {
+      pages.push(p);
+    }
+    if (end < totalPages - 1) {
+      pages.push('...');
+    }
+    if (totalPages > 1) {
+      pages.push(totalPages);
+    }
+
+    var html =
+      '<button type="button" class="pagination-btn pagination-prev" data-page="' +
+      (currentPage - 1) +
+      '"' +
+      (currentPage <= 1 ? ' disabled' : '') +
+      '>Prev</button>';
+    for (var k = 0; k < pages.length; k++) {
+      if (pages[k] === '...') {
+        html += '<span class="pagination-ellipsis">…</span>';
+      } else {
+        html +=
+          '<button type="button" class="pagination-btn pagination-page' +
+          (pages[k] === currentPage ? ' active' : '') +
+          '" data-page="' +
+          pages[k] +
+          '">' +
+          pages[k] +
+          '</button>';
+      }
+    }
+    html +=
+      '<button type="button" class="pagination-btn pagination-next" data-page="' +
+      (currentPage + 1) +
+      '"' +
+      (currentPage >= totalPages ? ' disabled' : '') +
+      '>Next</button>';
+
+    container.html(html).removeClass('hide');
+  };
+
+  var applyComponentsView = function() {
     var s = $('#search-filter').val(),
       a = $('#author-filter').val(),
       r = safeRegExp(s, ''),
       ar = safeRegExp(a, 'i'),
       selectedCheckboxes = $('input[type=checkbox]:checked'),
       hiddenStates = [],
-      hidden = 0,
+      matchingNames = [],
       i;
 
     for (i = 0; i < selectedCheckboxes.length; i++) {
       hiddenStates.push($(selectedCheckboxes[i]).attr('name'));
     }
 
+    // First pass: figure out which components match the current filters.
     for (i = 0; i < componentsList.length; i++) {
       var matches = !s || !!componentsList[i].name.match(r),
         matchesAuthor =
           !a ||
           (componentsList[i].author.name &&
             !!componentsList[i].author.name.match(ar)),
-        selector = $('#component-' + componentsList[i].name),
         isHidden = false;
 
       for (var j = 0; j < hiddenStates.length; j++) {
@@ -46,15 +109,41 @@ oc.cmd.push(function() {
         }
       }
 
-      var show = matches && matchesAuthor && !isHidden;
-      selector[show ? 'removeClass' : 'addClass']('hide');
-      if (!show) {
-        hidden += 1;
+      if (matches && matchesAuthor && !isHidden) {
+        matchingNames.push(componentsList[i].name);
       }
     }
 
-    var totalShowing = componentsList.length - hidden,
-      result = totalShowing + (totalShowing === 1 ? ' component' : ' components');
+    var totalMatching = matchingNames.length;
+    var totalPages = paginationEnabled
+      ? Math.max(1, Math.ceil(totalMatching / COMPONENTS_PAGE_SIZE))
+      : 1;
+    if (currentPage > totalPages) {
+      currentPage = totalPages;
+    }
+    if (currentPage < 1) {
+      currentPage = 1;
+    }
+
+    var startIdx = paginationEnabled
+      ? (currentPage - 1) * COMPONENTS_PAGE_SIZE
+      : 0;
+    var endIdx = paginationEnabled ? startIdx + COMPONENTS_PAGE_SIZE : totalMatching;
+    var visibleNames = {};
+    for (i = startIdx; i < endIdx && i < totalMatching; i++) {
+      visibleNames[matchingNames[i]] = true;
+    }
+
+    // Second pass: only rows that match the filters AND fall on the current
+    // page are shown.
+    for (i = 0; i < componentsList.length; i++) {
+      var name = componentsList[i].name,
+        show = visibleNames[name] === true;
+      $('#component-' + name)[show ? 'removeClass' : 'addClass']('hide');
+    }
+
+    var result =
+      totalMatching + (totalMatching === 1 ? ' component' : ' components');
 
     if (s) {
       result += ' matching "' + s + '"';
@@ -65,11 +154,29 @@ oc.cmd.push(function() {
     if (a) {
       result += ' by author "' + a + '"';
     }
+    if (paginationEnabled && totalMatching > COMPONENTS_PAGE_SIZE) {
+      result +=
+        ' (showing ' +
+        (startIdx + 1) +
+        '–' +
+        Math.min(endIdx, totalMatching) +
+        ')';
+    }
 
     $('#results-count').text(result);
-    $('#components-empty')[totalShowing === 0 ? 'removeClass' : 'addClass']('hide');
+    $('#components-empty')[totalMatching === 0 ? 'removeClass' : 'addClass'](
+      'hide'
+    );
+
+    renderComponentsPagination(totalMatching, totalPages);
 
     return false;
+  };
+
+  var componentsListChanged = function() {
+    // Any filter change resets back to the first page.
+    currentPage = 1;
+    return applyComponentsView();
   };
 
   var historyData = [];
@@ -249,6 +356,24 @@ oc.cmd.push(function() {
     .submit(componentsListChanged)
     .keyup(debounce(componentsListChanged, 80));
   $('#filter-components input[type=checkbox]').change(componentsListChanged);
+
+  $('#components-pagination').on('click', '.pagination-btn', function() {
+    var $btn = $(this);
+    if ($btn.is('[disabled]')) {
+      return;
+    }
+    var page = parseInt($btn.attr('data-page'), 10);
+    if (isNaN(page)) {
+      return;
+    }
+    currentPage = page;
+    applyComponentsView();
+    // Bring the top of the list back into view after switching pages.
+    var listEl = document.getElementById('components-list');
+    if (listEl && listEl.scrollIntoView) {
+      listEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  });
 
   if (q) {
     $('.search').val(q);

--- a/packages/oc/src/registry/views/static/index.ts
+++ b/packages/oc/src/registry/views/static/index.ts
@@ -24,9 +24,10 @@ oc.cmd.push(function() {
   var currentPage = 1;
 
   var renderComponentsPagination = function(totalMatching, totalPages) {
-    var container = $('#components-pagination');
+    // Rendered into both the top and bottom containers so they stay in sync.
+    var containers = $('.components-pagination');
     if (!paginationEnabled || totalMatching <= COMPONENTS_PAGE_SIZE) {
-      container.addClass('hide').empty();
+      containers.addClass('hide').empty();
       return;
     }
 
@@ -77,7 +78,7 @@ oc.cmd.push(function() {
       (currentPage >= totalPages ? ' disabled' : '') +
       '>Next</button>';
 
-    container.html(html).removeClass('hide');
+    containers.html(html).removeClass('hide');
   };
 
   var applyComponentsView = function() {
@@ -357,7 +358,9 @@ oc.cmd.push(function() {
     .keyup(debounce(componentsListChanged, 80));
   $('#filter-components input[type=checkbox]').change(componentsListChanged);
 
-  $('#components-pagination').on('click', '.pagination-btn', function() {
+  // Delegated from the stable list container so both the top and bottom
+  // pagination bars work. No auto-scroll, so repeated clicks stay put.
+  $('#components-list').on('click', '.pagination-btn', function() {
     var $btn = $(this);
     if ($btn.is('[disabled]')) {
       return;
@@ -368,11 +371,6 @@ oc.cmd.push(function() {
     }
     currentPage = page;
     applyComponentsView();
-    // Bring the top of the list back into view after switching pages.
-    var listEl = document.getElementById('components-list');
-    if (listEl && listEl.scrollIntoView) {
-      listEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
   });
 
   if (q) {

--- a/packages/oc/src/registry/views/static/style.ts
+++ b/packages/oc/src/registry/views/static/style.ts
@@ -1134,6 +1134,54 @@ select {
   vertical-align: middle;
 }
 
+/* ── Components pagination ──────────────────────────── */
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.pagination-btn {
+  min-width: 2.25rem;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.pagination-btn:hover:not([disabled]):not(.active) {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-hover);
+}
+
+.pagination-btn.active {
+  color: #fff;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  cursor: default;
+}
+
+.pagination-btn[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pagination-ellipsis {
+  padding: 0 0.25rem;
+  color: var(--color-text-muted);
+  user-select: none;
+}
+
 #history-error {
   text-align: center;
   padding: 1.5em 2em;

--- a/packages/oc/src/registry/views/static/style.ts
+++ b/packages/oc/src/registry/views/static/style.ts
@@ -1145,6 +1145,11 @@ select {
   border-top: 1px solid var(--color-border);
 }
 
+.pagination-top {
+  border-top: none;
+  border-bottom: 1px solid var(--color-border);
+}
+
 .pagination-btn {
   min-width: 2.25rem;
   padding: 0.4rem 0.6rem;


### PR DESCRIPTION
Adds client-side pagination to the registry UI Components tab. When there are more than 50 components, the list is split into pages of 50 with numbered Prev/Next controls; pagination works on top of the existing name/author/state filters and resets to page 1 whenever a filter changes.