### PR TITLE
Prepare registry routes for server adapters

### DIFF
--- a/packages/oc/src/registry/index.ts
+++ b/packages/oc/src/registry/index.ts
@@ -78,7 +78,7 @@ export default function registry<T = any>(inputOptions: RegistryOptions<T>) {
 
         if (options.verbosity) {
           ok(
-            `Registry started at port http://localhost:${app.get('port')}${options.prefix}`
+            `Registry started at port http://localhost:${options.port}${options.prefix}`
           );
 
           if (componentsInfo) {

--- a/packages/oc/src/registry/middleware/compression.ts
+++ b/packages/oc/src/registry/middleware/compression.ts
@@ -15,7 +15,7 @@ export default function compress(
     return;
   }
 
-  res.setHeader('Content-Encoding', encoding);
+  res.set('Content-Encoding', encoding);
   const compressed = encoding === 'br' ? data.brotli : data.gzip;
 
   res.send(compressed);

--- a/packages/oc/src/registry/middleware/cors.ts
+++ b/packages/oc/src/registry/middleware/cors.ts
@@ -6,13 +6,13 @@ export default function cors(
   next: NextFunction
 ): void {
   res.removeHeader('X-Powered-By');
-  res.header('Access-Control-Allow-Credentials', 'true');
-  res.header('Access-Control-Allow-Origin', '*');
-  res.header(
+  res.set('Access-Control-Allow-Credentials', 'true');
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set(
     'Access-Control-Allow-Headers',
     'Origin, X-Requested-With, Content-Type, Accept, traceparent'
   );
-  res.header('Access-Control-Allow-Methods', 'GET, OPTIONS, PUT, POST');
+  res.set('Access-Control-Allow-Methods', 'GET, OPTIONS, PUT, POST');
 
   next();
 }

--- a/packages/oc/src/registry/router.ts
+++ b/packages/oc/src/registry/router.ts
@@ -22,7 +22,12 @@ export function create(app: Express, conf: Config, repository: Repository) {
     componentPreview: ComponentPreviewRoute(conf, repository),
     index: IndexRoute(repository),
     publish: PublishRoute(repository),
-    staticRedirector: StaticRedirectorRoute(repository),
+    staticRedirector: {
+      client: StaticRedirectorRoute(repository, 'client'),
+      devClient: StaticRedirectorRoute(repository, 'dev-client'),
+      clientMap: StaticRedirectorRoute(repository, 'client-map'),
+      localStatic: StaticRedirectorRoute(repository, 'local-static')
+    },
     plugins: PluginsRoute(conf),
     dependencies: DependenciesRoute(conf),
     history: HistoryRoute(repository),
@@ -38,9 +43,15 @@ export function create(app: Express, conf: Config, repository: Repository) {
     app.get(prefix.substring(0, prefix.length - 1), routes.index);
   }
 
-  app.get(`${prefix}oc-client/client.js`, routes.staticRedirector);
-  app.get(`${prefix}oc-client/client.dev.js`, routes.staticRedirector);
-  app.get(`${prefix}oc-client/oc-client.min.map`, routes.staticRedirector);
+  app.get(`${prefix}oc-client/client.js`, routes.staticRedirector.client);
+  app.get(
+    `${prefix}oc-client/client.dev.js`,
+    routes.staticRedirector.devClient
+  );
+  app.get(
+    `${prefix}oc-client/oc-client.min.map`,
+    routes.staticRedirector.clientMap
+  );
 
   app.get(`${prefix}~registry/plugins`, routes.plugins);
   app.get(`${prefix}~registry/dependencies`, routes.dependencies);
@@ -52,7 +63,7 @@ export function create(app: Express, conf: Config, repository: Repository) {
   if (conf.local) {
     app.get(
       `${prefix}:componentName/:componentVersion/${settings.registry.localStaticRedirectorPath}*splat`,
-      routes.staticRedirector
+      routes.staticRedirector.localStatic
     );
   } else {
     app.put(

--- a/packages/oc/src/registry/routes/component.ts
+++ b/packages/oc/src/registry/routes/component.ts
@@ -70,7 +70,7 @@ export default function component(
               res.status(500).end(String(err));
             });
 
-            res.setHeader('Content-Type', 'x-text/stream');
+            res.set('Content-Type', 'x-text/stream');
 
             nodeStream.pipe(res).on('finish', () => {
               res.end();

--- a/packages/oc/src/registry/routes/history.ts
+++ b/packages/oc/src/registry/routes/history.ts
@@ -8,7 +8,7 @@ export default function history(repository: Repository) {
       if (res.conf.discovery.ui && !res.conf.local) {
         const details = await repository.getComponentsDetails();
         const componentsHistory = getComponentsHistory(details);
-        res.setHeader('Cache-Control', 'public, max-age=600');
+        res.set('Cache-Control', 'public, max-age=600');
         res.status(200).json({ componentsHistory });
       } else {
         res.status(401);

--- a/packages/oc/src/registry/routes/static-redirector.ts
+++ b/packages/oc/src/registry/routes/static-redirector.ts
@@ -6,16 +6,20 @@ import * as storageUtils from 'oc-storage-adapters-utils';
 import type { Repository } from '../domain/repository';
 import compress from '../middleware/compression';
 
-export default function staticRedirector(repository: Repository) {
+export type StaticRedirectorRouteId =
+  | 'client'
+  | 'dev-client'
+  | 'client-map'
+  | 'local-static';
+
+export default function staticRedirector(
+  repository: Repository,
+  routeId: StaticRedirectorRouteId
+) {
   return (req: Request, res: Response): void => {
     let filePath: string;
-    const clientPath = `${res.conf.prefix || '/'}oc-client/client.js`;
-    const devClientPath = `${res.conf.prefix || '/'}oc-client/client.dev.js`;
-    const clientMapPath = `${
-      res.conf.prefix || '/'
-    }oc-client/oc-client.min.map`;
 
-    if (req.route.path === clientPath || req.route.path === devClientPath) {
+    if (routeId === 'client' || routeId === 'dev-client') {
       if (res.conf.local) {
         if (res.conf.compiledClient) {
           res.type('application/javascript');
@@ -29,7 +33,7 @@ export default function staticRedirector(repository: Repository) {
       } else {
         if (res.conf.compiledClient) {
           res.type('application/javascript');
-          if (req.route.path === clientPath) {
+          if (routeId === 'client') {
             compress(
               {
                 uncompressed: res.conf.compiledClient.code.minified,
@@ -44,12 +48,10 @@ export default function staticRedirector(repository: Repository) {
           }
           return;
         }
-        res.redirect(
-          repository.getStaticClientPath(req.route.path === devClientPath)
-        );
+        res.redirect(repository.getStaticClientPath(routeId === 'dev-client'));
         return;
       }
-    } else if (req.route.path === clientMapPath) {
+    } else if (routeId === 'client-map') {
       if (res.conf.local) {
         filePath = path.join(
           __dirname,


### PR DESCRIPTION
## Summary
- Remove `req.route.path` dependency by registering static redirector handlers with explicit route identities
- Use `options.port` for the startup log instead of Express app settings
- Normalize registry response header writes to `res.set(...)`

#### Test plan
- [x] `npm run build -w oc`
- [x] `npm run test -w oc`

Generated with [Devin](https://devin.ai)