### PR TITLE
Cache neutral facade once per request in Express adapter

### DIFF
--- a/packages/oc/src/registry/domain/http-server/express-adapter.ts
+++ b/packages/oc/src/registry/domain/http-server/express-adapter.ts
@@ -16,10 +16,29 @@ import type {
 } from './types';
 
 const expressMiddleware = Symbol('expressMiddleware');
+const ocResponseSym = Symbol('ocResponse');
+const ocParamsSym = Symbol('ocParams');
 
 type WrappedOcHandler = OcHandler & {
   [expressMiddleware]?: ExpressMiddleware;
 };
+
+interface ParamsMemo {
+  source: object;
+}
+
+function stream(this: OcResponse, readable: NodeJS.ReadableStream): void {
+  readable.pipe(this.raw);
+}
+
+function normaliseParams(raw: Record<string, unknown>): Record<string, string> {
+  const params: Record<string, string> = { ...(raw as Record<string, string>) };
+  const splat = raw['splat'];
+  if (Array.isArray(splat)) {
+    params['splat'] = splat.join('/');
+  }
+  return params;
+}
 
 export default function createExpressAdapter(
   port?: number | string
@@ -187,41 +206,70 @@ class ExpressHttpServerAdapter implements HttpServerAdapter {
     }
 
     return (req, res, next) => {
-      Promise.resolve(
-        handler(
+      let result: unknown;
+      try {
+        result = handler(
           this.toOcRequest(req as Request),
           this.toOcResponse(res as Response)
-        )
-      )
-        .then(() => {
-          if (continueWhenNotSent && !(res as Response).headersSent) {
-            next();
-          }
-        })
-        .catch(next);
+        );
+      } catch (err) {
+        next(err);
+        return;
+      }
+
+      if (result && typeof (result as Promise<void>).then === 'function') {
+        (result as Promise<void>)
+          .then(() => {
+            if (continueWhenNotSent && !(res as Response).headersSent) {
+              next();
+            }
+          })
+          .catch(next);
+      } else if (continueWhenNotSent && !(res as Response).headersSent) {
+        next();
+      }
     };
   }
 
   private toOcRequest(req: Request): OcRequest {
-    const rawParams = req.params ?? {};
-    const params = { ...rawParams } as Record<string, string>;
-    if (Array.isArray(rawParams['splat'])) {
-      params['splat'] = rawParams['splat'].join('/');
+    const memo = (req as unknown as { [ocParamsSym]?: ParamsMemo })[
+      ocParamsSym
+    ];
+    const current = (req.params ?? {}) as object;
+    if (memo && memo.source === current) {
+      return req as unknown as OcRequest;
     }
 
-    return Object.assign(req, {
-      params,
-      raw: req,
-      routeId: (req as unknown as { routeId?: string }).routeId ?? ''
-    }) as unknown as OcRequest;
+    if (!memo) {
+      Object.assign(req, {
+        raw: req,
+        routeId: (req as unknown as { routeId?: string }).routeId ?? ''
+      });
+    }
+
+    const normalized = normaliseParams(current as Record<string, unknown>);
+    Object.assign(req, { params: normalized });
+    (req as unknown as { [ocParamsSym]: ParamsMemo })[ocParamsSym] = {
+      source: normalized
+    };
+
+    return req as unknown as OcRequest;
   }
 
   private toOcResponse(res: Response): OcResponse {
-    return Object.assign(res, {
+    const cached = (res as unknown as { [ocResponseSym]?: OcResponse })[
+      ocResponseSym
+    ];
+    if (cached) {
+      return cached;
+    }
+
+    const ocRes = Object.assign(res, {
       raw: res,
-      stream: (readable: NodeJS.ReadableStream) => {
-        readable.pipe(res);
-      }
+      stream
     }) as unknown as OcResponse;
+
+    (res as unknown as { [ocResponseSym]: OcResponse })[ocResponseSym] = ocRes;
+    return ocRes;
   }
 }

--- a/packages/oc/test/acceptance/registry.js
+++ b/packages/oc/test/acceptance/registry.js
@@ -1099,4 +1099,39 @@ describe('registry', () => {
       });
     });
   });
+
+  describe('GET /:componentName/:componentVersion/static/*splat (local-mode static route)', () => {
+    describe('when requesting an existing packaged file', () => {
+      before((done) => {
+        next(
+          request('http://localhost:3030/hello-world/1.0.0/static/package.json'),
+          done
+        );
+      });
+
+      it('should respond with 200', () => {
+        expect(status).to.equal(200);
+      });
+
+      it('should respond with the packaged file contents', () => {
+        expect(result.name).to.equal('hello-world');
+        expect(result.version).to.equal('1.0.0');
+      });
+    });
+
+    describe('when requesting a missing file', () => {
+      before((done) => {
+        next(
+          request(
+            'http://localhost:3030/hello-world/1.0.0/static/does-not-exist.txt'
+          ),
+          done
+        );
+      });
+
+      it('should respond with 404', () => {
+        expect(status).to.equal(404);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Stacked on #1510 (phase 4). Tackles the per-call request/response facade wrapping overhead introduced in the phase-4 Express adapter.

- Cache `OcResponse` on the underlying res via a `Symbol`; the handler chain (~6-7 wraps/request) now reuses one instance instead of re-running `Object.assign` per call.
- Hoist the `res.stream` closure to a single shared function (`readable.pipe(this.raw)`) so a fresh closure is no longer allocated per wrapped handler.
- Memoize normalized `req.params` keyed on the identity of `req.params`; recompute only when Express reassigns it (new router layer), collapse the per-handler `{ ...params }` spread + splat-join to once per route layer. Initialize `raw`/`routeId` once.
- Synchronous `next()` fast path in `toExpressHandler`: only defer via a microtask when the handler actually returns a thenable. Sync middlewares (`res.conf`, `cors`, `baseUrl`, `discovery`) and sync route handlers no longer pay the unconditional `Promise.resolve(...).then(next)` microtask.
- Add acceptance coverage for the local-mode static route (\`GET /:componentName/:componentVersion/static/*splat\`) — the gap that let the phase-4 splat crash slip through.

Behaviour preserved: `use()` handlers continue the chain if they didn't send; route handlers never auto-`next()`; `req.params.splat` stays a slash-joined string. Public contract (`Registry().app`, `{ app, server }`, Express augmentation) untouched. Establishes the convert-once + cache pattern the future Fastify adapter (phase 6) should mirror via `decorateRequest`/`decorateReply` + `onRequest`.

#### Test plan
- [x] \`npx @biomejs/biome check --write \"packages/oc/src/registry\"\`
- [x] \`npm run build -w oc\`
- [x] \`npm run test -w oc\` — 930 passing (927 baseline + 3 new)