### PR TITLE
Stop oc.build from appending trailing slashes to hrefs

### DIFF
--- a/.changeset/clean-hrefs-build.md
+++ b/.changeset/clean-hrefs-build.md
@@ -1,0 +1,5 @@
+---
+"oc-client-browser": minor
+---
+
+Stop `oc.build` from appending a trailing slash to component hrefs

--- a/packages/oc-client-browser/DOCS.md
+++ b/packages/oc-client-browser/DOCS.md
@@ -84,7 +84,7 @@ var html = oc.build({
   }
 });
 
-// html => <oc-component href="https://my-registry.com/components/my-component/~2.3.4/?age=23&hello=world"></oc-component>
+// html => <oc-component href="https://my-registry.com/components/my-component/~2.3.4?age=23&hello=world"></oc-component>
 ```
 
 ### oc.events.on(eventName, callback);

--- a/packages/oc-client-browser/src/oc-client.js
+++ b/packages/oc-client-browser/src/oc-client.js
@@ -340,16 +340,11 @@ export function createOc(oc) {
     isRequired('baseUrl', options.baseUrl);
     isRequired('name', options.name);
 
-    let withFinalSlash = (s) => {
-      if (!s) return '';
-
-      return s.match(/\/$/) ? s : s + '/';
-    };
-
     let href =
-      withFinalSlash(options.baseUrl) +
-      withFinalSlash(options.name) +
-      withFinalSlash(options.version);
+      options.baseUrl.replace(/\/$/, '') +
+      '/' +
+      options.name +
+      (options.version ? '/' + options.version : '');
 
     if (options.parameters) {
       href += '?';

--- a/packages/oc-client-browser/tests/buildHref.spec.js
+++ b/packages/oc-client-browser/tests/buildHref.spec.js
@@ -1,195 +1,195 @@
 // @ts-check
-import { expect, test } from "@playwright/test";
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
-	await page.goto("/");
+  await page.goto('/');
 });
 
-test.describe("oc-client : build", () => {
-	test("should throw when building a component without baseUrl", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			try {
-				oc.build({ name: "someName" });
-				return { success: true };
-			} catch (error) {
-				return { success: false, message: error.message || error };
-			}
-		});
+test.describe('oc-client : build', () => {
+  test('should throw when building a component without baseUrl', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      try {
+        oc.build({ name: 'someName' });
+        return { success: true };
+      } catch (error) {
+        return { success: false, message: error.message || error };
+      }
+    });
 
-		expect(result.success).toBeFalsy();
-		expect(result.message).toEqual("baseUrl parameter is required");
-	});
+    expect(result.success).toBeFalsy();
+    expect(result.message).toEqual('baseUrl parameter is required');
+  });
 
-	test("should throw when building a component without name", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			try {
-				oc.build({ baseUrl: "http://www.opencomponents.com" });
-				return { success: true };
-			} catch (error) {
-				return { success: false, message: error.message || error };
-			}
-		});
+  test('should throw when building a component without name', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      try {
+        oc.build({ baseUrl: 'http://www.opencomponents.com' });
+        return { success: true };
+      } catch (error) {
+        return { success: false, message: error.message || error };
+      }
+    });
 
-		expect(result.success).toBeFalsy();
-		expect(result.message).toEqual("name parameter is required");
-	});
+    expect(result.success).toBeFalsy();
+    expect(result.message).toEqual('name parameter is required');
+  });
 
-	test("should build with baseUrl and name parameters", async ({ page }) => {
-		const result = await page.evaluate(() => {
-			return oc.build({
-				baseUrl: "http://www.components.com/v2",
-				name: "myComponent",
-			});
-		});
+  test('should build with baseUrl and name parameters', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      return oc.build({
+        baseUrl: 'http://www.components.com/v2',
+        name: 'myComponent'
+      });
+    });
 
-		expect(result).toEqual(
-			'<oc-component href="http://www.components.com/v2/myComponent/"></oc-component>',
-		);
-	});
+    expect(result).toEqual(
+      '<oc-component href="http://www.components.com/v2/myComponent"></oc-component>'
+    );
+  });
 
-	test("should handle trailing slash in baseUrl", async ({ page }) => {
-		const result = await page.evaluate(() => {
-			return oc.build({
-				baseUrl: "http://www.components.com/v2/",
-				name: "myComponent",
-			});
-		});
+  test('should handle trailing slash in baseUrl', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      return oc.build({
+        baseUrl: 'http://www.components.com/v2/',
+        name: 'myComponent'
+      });
+    });
 
-		expect(result).toEqual(
-			'<oc-component href="http://www.components.com/v2/myComponent/"></oc-component>',
-		);
-	});
+    expect(result).toEqual(
+      '<oc-component href="http://www.components.com/v2/myComponent"></oc-component>'
+    );
+  });
 
-	test("should build with baseUrl, name, and parameters", async ({ page }) => {
-		const result = await page.evaluate(() => {
-			return oc.build({
-				baseUrl: "http://www.components.com/v2",
-				name: "myComponent",
-				parameters: {
-					hello: "world",
-					integer: 123,
-					boo: true,
-				},
-			});
-		});
+  test('should build with baseUrl, name, and parameters', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      return oc.build({
+        baseUrl: 'http://www.components.com/v2',
+        name: 'myComponent',
+        parameters: {
+          hello: 'world',
+          integer: 123,
+          boo: true
+        }
+      });
+    });
 
-		const expectedHref =
-			"http://www.components.com/v2/myComponent/?hello=world&integer=123&boo=true";
-		const expected = `<oc-component href="${expectedHref}"></oc-component>`;
-		expect(result).toEqual(expected);
-	});
+    const expectedHref =
+      'http://www.components.com/v2/myComponent?hello=world&integer=123&boo=true';
+    const expected = `<oc-component href="${expectedHref}"></oc-component>`;
+    expect(result).toEqual(expected);
+  });
 
-	test("should build with baseUrl, name, and version", async ({ page }) => {
-		const result = await page.evaluate(() => {
-			return oc.build({
-				baseUrl: "http://www.components.com/v2",
-				name: "myComponent",
-				version: "1.0.X",
-			});
-		});
+  test('should build with baseUrl, name, and version', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      return oc.build({
+        baseUrl: 'http://www.components.com/v2',
+        name: 'myComponent',
+        version: '1.0.X'
+      });
+    });
 
-		const expectedHref = "http://www.components.com/v2/myComponent/1.0.X/";
-		const expected = `<oc-component href="${expectedHref}"></oc-component>`;
-		expect(result).toEqual(expected);
-	});
+    const expectedHref = 'http://www.components.com/v2/myComponent/1.0.X';
+    const expected = `<oc-component href="${expectedHref}"></oc-component>`;
+    expect(result).toEqual(expected);
+  });
 
-	test("should build with baseUrl, name, parameters, and version", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			return oc.build({
-				baseUrl: "http://www.components.com/v2",
-				name: "myComponent",
-				parameters: {
-					hello: "world",
-					integer: 123,
-					boo: true,
-				},
-				version: "1.2.3",
-			});
-		});
+  test('should build with baseUrl, name, parameters, and version', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      return oc.build({
+        baseUrl: 'http://www.components.com/v2',
+        name: 'myComponent',
+        parameters: {
+          hello: 'world',
+          integer: 123,
+          boo: true
+        },
+        version: '1.2.3'
+      });
+    });
 
-		const expectedHref =
-			"http://www.components.com/v2/myComponent/1.2.3/?hello=world&integer=123&boo=true";
-		const expected = `<oc-component href="${expectedHref}"></oc-component>`;
-		expect(result).toEqual(expected);
-	});
+    const expectedHref =
+      'http://www.components.com/v2/myComponent/1.2.3?hello=world&integer=123&boo=true';
+    const expected = `<oc-component href="${expectedHref}"></oc-component>`;
+    expect(result).toEqual(expected);
+  });
 
-	test("should preserve special characters in parameter values", async ({
-		page,
-	}) => {
-		const specialCharsResult = await page.evaluate(() => {
-			return oc.build({
-				baseUrl: "http://www.components.com/v2",
-				name: "myComponent",
-				parameters: {
-					message1: "Jack&Jane",
-					message2: "Jane+Joseph",
-					message3: "Joseph=Joe",
-					message4: "Jamie?James",
-				},
-			});
-		});
+  test('should preserve special characters in parameter values', async ({
+    page
+  }) => {
+    const specialCharsResult = await page.evaluate(() => {
+      return oc.build({
+        baseUrl: 'http://www.components.com/v2',
+        name: 'myComponent',
+        parameters: {
+          message1: 'Jack&Jane',
+          message2: 'Jane+Joseph',
+          message3: 'Joseph=Joe',
+          message4: 'Jamie?James'
+        }
+      });
+    });
 
-		// Parse the querystring from the result
-		const specialCharsQuerystring = await page.evaluate((result) => {
-			const match = /href=".*?\?(.*?)"/.exec(result);
-			return match ? match[1] : "";
-		}, specialCharsResult);
+    // Parse the querystring from the result
+    const specialCharsQuerystring = await page.evaluate((result) => {
+      const match = /href=".*?\?(.*?)"/.exec(result);
+      return match ? match[1] : '';
+    }, specialCharsResult);
 
-		// Extract and check parameter values
-		const parameters = await page.evaluate((querystring) => {
-			// Simple querystring parser
-			const params = {};
-			const pairs = querystring.split("&");
-			for (let i = 0; i < pairs.length; i++) {
-				const pair = pairs[i].split("=");
-				params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
-			}
-			return params;
-		}, specialCharsQuerystring);
+    // Extract and check parameter values
+    const parameters = await page.evaluate((querystring) => {
+      // Simple querystring parser
+      const params = {};
+      const pairs = querystring.split('&');
+      for (let i = 0; i < pairs.length; i++) {
+        const pair = pairs[i].split('=');
+        params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+      }
+      return params;
+    }, specialCharsQuerystring);
 
-		expect(parameters.message1).toEqual("Jack&Jane");
-		expect(parameters.message2).toEqual("Jane+Joseph");
-		expect(parameters.message3).toEqual("Joseph=Joe");
-		expect(parameters.message4).toEqual("Jamie?James");
-	});
+    expect(parameters.message1).toEqual('Jack&Jane');
+    expect(parameters.message2).toEqual('Jane+Joseph');
+    expect(parameters.message3).toEqual('Joseph=Joe');
+    expect(parameters.message4).toEqual('Jamie?James');
+  });
 
-	test("should decode encoded characters in parameter values", async ({
-		page,
-	}) => {
-		const encodedResult = await page.evaluate(() => {
-			return oc.build({
-				baseUrl: "http://www.components.com/v2",
-				name: "myComponent",
-				parameters: {
-					gpid: "fhdDk612M4mjT70xkKCZRg%3d%3d",
-				},
-			});
-		});
+  test('should decode encoded characters in parameter values', async ({
+    page
+  }) => {
+    const encodedResult = await page.evaluate(() => {
+      return oc.build({
+        baseUrl: 'http://www.components.com/v2',
+        name: 'myComponent',
+        parameters: {
+          gpid: 'fhdDk612M4mjT70xkKCZRg%3d%3d'
+        }
+      });
+    });
 
-		// Parse the querystring from the result
-		const encodedQuerystring = await page.evaluate((result) => {
-			const match = /href=".*?\?(.*?)"/.exec(result);
-			return match ? match[1] : "";
-		}, encodedResult);
+    // Parse the querystring from the result
+    const encodedQuerystring = await page.evaluate((result) => {
+      const match = /href=".*?\?(.*?)"/.exec(result);
+      return match ? match[1] : '';
+    }, encodedResult);
 
-		// Extract and check parameter values
-		const encodedParameters = await page.evaluate((querystring) => {
-			// Simple querystring parser
-			const params = {};
-			const pairs = querystring.split("&");
-			for (let i = 0; i < pairs.length; i++) {
-				const pair = pairs[i].split("=");
-				params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
-			}
-			return params;
-		}, encodedQuerystring);
+    // Extract and check parameter values
+    const encodedParameters = await page.evaluate((querystring) => {
+      // Simple querystring parser
+      const params = {};
+      const pairs = querystring.split('&');
+      for (let i = 0; i < pairs.length; i++) {
+        const pair = pairs[i].split('=');
+        params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+      }
+      return params;
+    }, encodedQuerystring);
 
-		expect(encodedParameters.gpid).toEqual("fhdDk612M4mjT70xkKCZRg==");
-	});
+    expect(encodedParameters.gpid).toEqual('fhdDk612M4mjT70xkKCZRg==');
+  });
 });

--- a/packages/oc-client-browser/tests/edgeCases.spec.js
+++ b/packages/oc-client-browser/tests/edgeCases.spec.js
@@ -1,274 +1,284 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
-	await page.goto("/");
+  await page.goto('/');
 });
 
-test.describe("oc-client : edge cases", () => {
-	test.beforeEach(async ({ page }) => {
-		await page.evaluate(() => {
-			window.originalConsoleLog = console.log;
-			console.log = () => {};
-		});
-	});
+test.describe('oc-client : edge cases', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => {
+      window.originalConsoleLog = console.log;
+      console.log = () => {};
+    });
+  });
 
-	test.afterEach(async ({ page }) => {
-		await page.evaluate(() => {
-			console.log = window.originalConsoleLog;
-			delete window.originalConsoleLog;
-		});
-	});
+  test.afterEach(async ({ page }) => {
+    await page.evaluate(() => {
+      console.log = window.originalConsoleLog;
+      delete window.originalConsoleLog;
+    });
+  });
 
-	test("should handle build with special characters in parameters", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			const options = {
-				baseUrl: "https://example.com",
-				name: "test-component",
-				version: "1.0.0",
-				parameters: {
-					message: "Hello & Welcome!",
-					query: "search=test+value",
-					encoded: "already%20encoded",
-					symbols: "!@#$%^&*()",
-				},
-			};
+  test('should handle build with special characters in parameters', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      const options = {
+        baseUrl: 'https://example.com',
+        name: 'test-component',
+        version: '1.0.0',
+        parameters: {
+          message: 'Hello & Welcome!',
+          query: 'search=test+value',
+          encoded: 'already%20encoded',
+          symbols: '!@#$%^&*()'
+        }
+      };
 
-			return {
-				html: oc.build(options),
-			};
-		});
+      return {
+        html: oc.build(options)
+      };
+    });
 
-		expect(result.html).toContain("oc-component");
-		expect(result.html).toContain("href=");
-		expect(result.html).toContain("Hello%20%26%20Welcome!");
-		expect(result.html).toContain("search%3Dtest%2Bvalue");
-	});
+    expect(result.html).toContain('oc-component');
+    expect(result.html).toContain('href=');
+    expect(result.html).toContain('Hello%20%26%20Welcome!');
+    expect(result.html).toContain('search%3Dtest%2Bvalue');
+  });
 
-	test("should handle build with empty parameters", async ({ page }) => {
-		const result = await page.evaluate(() => {
-			const options = {
-				baseUrl: "https://example.com",
-				name: "test-component",
-				version: "1.0.0",
-				parameters: {},
-			};
+  test('should handle build with empty parameters', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const options = {
+        baseUrl: 'https://example.com',
+        name: 'test-component',
+        version: '1.0.0',
+        parameters: {}
+      };
 
-			return {
-				html: oc.build(options),
-			};
-		});
+      return {
+        html: oc.build(options)
+      };
+    });
 
-		expect(result.html).toContain("oc-component");
-		expect(result.html).toContain("test-component/1.0.0/");
-		expect(result.html).not.toContain("?");
-	});
+    expect(result.html).toContain('oc-component');
+    expect(result.html).toContain('test-component/1.0.0');
+    expect(result.html).not.toContain('test-component/1.0.0/');
+    expect(result.html).not.toContain('?');
+  });
 
-	test("should handle build without version", async ({ page }) => {
-		const result = await page.evaluate(() => {
-			const options = {
-				baseUrl: "https://example.com",
-				name: "test-component",
-			};
+  test('should handle build without version', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const options = {
+        baseUrl: 'https://example.com',
+        name: 'test-component'
+      };
 
-			return {
-				html: oc.build(options),
-			};
-		});
+      return {
+        html: oc.build(options)
+      };
+    });
 
-		expect(result.html).toContain("oc-component");
-		expect(result.html).toContain("test-component/");
-		expect(result.html).toContain('href="https://example.com/test-component/"');
-	});
+    expect(result.html).toContain('oc-component');
+    expect(result.html).toContain('test-component');
+    expect(result.html).toContain('href="https://example.com/test-component"');
+    expect(result.html).not.toContain(
+      'href="https://example.com/test-component/"'
+    );
+  });
 
-	test("should handle build with baseUrl having trailing slash", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			const options1 = {
-				baseUrl: "https://example.com/",
-				name: "test-component",
-				version: "1.0.0",
-			};
+  test('should handle build with baseUrl having trailing slash', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      const options1 = {
+        baseUrl: 'https://example.com/',
+        name: 'test-component',
+        version: '1.0.0'
+      };
 
-			const options2 = {
-				baseUrl: "https://example.com",
-				name: "test-component",
-				version: "1.0.0",
-			};
+      const options2 = {
+        baseUrl: 'https://example.com',
+        name: 'test-component',
+        version: '1.0.0'
+      };
 
-			return {
-				html1: oc.build(options1),
-				html2: oc.build(options2),
-			};
-		});
+      return {
+        html1: oc.build(options1),
+        html2: oc.build(options2)
+      };
+    });
 
-		expect(result.html1).toContain("https://example.com/test-component/1.0.0/");
-		expect(result.html2).toContain("https://example.com/test-component/1.0.0/");
-		expect(result.html1).toBe(result.html2);
-	});
+    expect(result.html1).toContain('https://example.com/test-component/1.0.0');
+    expect(result.html2).toContain('https://example.com/test-component/1.0.0');
+    expect(result.html1).not.toContain(
+      'https://example.com/test-component/1.0.0/'
+    );
+    expect(result.html2).not.toContain(
+      'https://example.com/test-component/1.0.0/'
+    );
+    expect(result.html1).toBe(result.html2);
+  });
 
-	test("should handle renderNestedComponent with jQuery-like object", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			return new Promise((resolve) => {
-				const element = document.createElement("oc-component");
-				element.setAttribute("href", "https://example.com/component");
-				element.setAttribute("id", "test-component");
-				document.body.appendChild(element);
+  test('should handle renderNestedComponent with jQuery-like object', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        const element = document.createElement('oc-component');
+        element.setAttribute('href', 'https://example.com/component');
+        element.setAttribute('id', 'test-component');
+        document.body.appendChild(element);
 
-				const jqueryLikeObject = [element];
-				jqueryLikeObject[0] = element;
+        const jqueryLikeObject = [element];
+        jqueryLikeObject[0] = element;
 
-				let callbackCalled = false;
+        let callbackCalled = false;
 
-				oc.renderNestedComponent(jqueryLikeObject, () => {
-					callbackCalled = true;
-				});
+        oc.renderNestedComponent(jqueryLikeObject, () => {
+          callbackCalled = true;
+        });
 
-				setTimeout(() => {
-					resolve({
-						callbackCalled,
-						elementHasDataRendering: element.hasAttribute("data-rendering"),
-						elementDataRendering: element.getAttribute("data-rendering"),
-					});
-				}, 100);
-			});
-		});
+        setTimeout(() => {
+          resolve({
+            callbackCalled,
+            elementHasDataRendering: element.hasAttribute('data-rendering'),
+            elementDataRendering: element.getAttribute('data-rendering')
+          });
+        }, 100);
+      });
+    });
 
-		expect(result.elementHasDataRendering).toBe(true);
-		expect(result.elementDataRendering).toBe("true");
-	});
+    expect(result.elementHasDataRendering).toBe(true);
+    expect(result.elementDataRendering).toBe('true');
+  });
 
-	test("should handle renderNestedComponent with already rendered component", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			return new Promise((resolve) => {
-				const element = document.createElement("oc-component");
-				element.setAttribute("href", "https://example.com/component");
-				element.setAttribute("id", "test-component");
-				element.setAttribute("data-rendered", "true");
-				document.body.appendChild(element);
+  test('should handle renderNestedComponent with already rendered component', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        const element = document.createElement('oc-component');
+        element.setAttribute('href', 'https://example.com/component');
+        element.setAttribute('id', 'test-component');
+        element.setAttribute('data-rendered', 'true');
+        document.body.appendChild(element);
 
-				let callbackCalled = false;
-				const startTime = Date.now();
+        let callbackCalled = false;
+        const startTime = Date.now();
 
-				oc.renderNestedComponent(element, () => {
-					callbackCalled = true;
-					const endTime = Date.now();
-					resolve({
-						callbackCalled,
-						timeTaken: endTime - startTime,
-						wasDelayed: endTime - startTime >= 400,
-					});
-				});
-			});
-		});
+        oc.renderNestedComponent(element, () => {
+          callbackCalled = true;
+          const endTime = Date.now();
+          resolve({
+            callbackCalled,
+            timeTaken: endTime - startTime,
+            wasDelayed: endTime - startTime >= 400
+          });
+        });
+      });
+    });
 
-		expect(result.callbackCalled).toBe(true);
-		expect(result.wasDelayed).toBe(false);
-	});
+    expect(result.callbackCalled).toBe(true);
+    expect(result.wasDelayed).toBe(false);
+  });
 
-	test("should handle renderNestedComponent with currently rendering component", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			return new Promise((resolve) => {
-				const element = document.createElement("oc-component");
-				element.setAttribute("href", "https://example.com/component");
-				element.setAttribute("id", "test-component");
-				element.setAttribute("data-rendering", "true");
-				document.body.appendChild(element);
+  test('should handle renderNestedComponent with currently rendering component', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        const element = document.createElement('oc-component');
+        element.setAttribute('href', 'https://example.com/component');
+        element.setAttribute('id', 'test-component');
+        element.setAttribute('data-rendering', 'true');
+        document.body.appendChild(element);
 
-				let callbackCalled = false;
-				const startTime = Date.now();
+        let callbackCalled = false;
+        const startTime = Date.now();
 
-				oc.renderNestedComponent(element, () => {
-					callbackCalled = true;
-					const endTime = Date.now();
-					resolve({
-						callbackCalled,
-						timeTaken: endTime - startTime,
-						wasDelayed: endTime - startTime >= 400,
-					});
-				});
+        oc.renderNestedComponent(element, () => {
+          callbackCalled = true;
+          const endTime = Date.now();
+          resolve({
+            callbackCalled,
+            timeTaken: endTime - startTime,
+            wasDelayed: endTime - startTime >= 400
+          });
+        });
 
-				setTimeout(() => {
-					element.setAttribute("data-rendering", "false");
-					element.setAttribute("data-rendered", "true");
-				}, 200);
-			});
-		});
+        setTimeout(() => {
+          element.setAttribute('data-rendering', 'false');
+          element.setAttribute('data-rendered', 'true');
+        }, 200);
+      });
+    });
 
-		expect(result.callbackCalled).toBe(true);
-		expect(result.wasDelayed).toBe(true);
-	});
+    expect(result.callbackCalled).toBe(true);
+    expect(result.wasDelayed).toBe(true);
+  });
 
-	test("should handle getAction with missing component", async ({ page }) => {
-		const result = await page.evaluate(() => {
-			return new Promise((resolve) => {
-				oc.getAction({ component: "non-existent-component" })
-					.then((props) => {
-						resolve({
-							success: true,
-							props: props,
-						});
-					})
-					.catch((error) => {
-						resolve({
-							success: false,
-							error: error.message || error,
-						});
-					});
-			});
-		});
+  test('should handle getAction with missing component', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        oc.getAction({ component: 'non-existent-component' })
+          .then((props) => {
+            resolve({
+              success: true,
+              props: props
+            });
+          })
+          .catch((error) => {
+            resolve({
+              success: false,
+              error: error.message || error
+            });
+          });
+      });
+    });
 
-		expect(result.success).toBe(false);
-		expect(result.error).toBeDefined();
-	});
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
 
-	test("should handle multiple rapid renderUnloadedComponents calls", async ({
-		page,
-	}) => {
-		const result = await page.evaluate(() => {
-			return new Promise((resolve) => {
-				const component1 = document.createElement("oc-component");
-				component1.setAttribute("href", "https://example.com/component1");
-				component1.setAttribute("id", "component1");
-				document.body.appendChild(component1);
+  test('should handle multiple rapid renderUnloadedComponents calls', async ({
+    page
+  }) => {
+    const result = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        const component1 = document.createElement('oc-component');
+        component1.setAttribute('href', 'https://example.com/component1');
+        component1.setAttribute('id', 'component1');
+        document.body.appendChild(component1);
 
-				const component2 = document.createElement("oc-component");
-				component2.setAttribute("href", "https://example.com/component2");
-				component2.setAttribute("id", "component2");
-				document.body.appendChild(component2);
+        const component2 = document.createElement('oc-component');
+        component2.setAttribute('href', 'https://example.com/component2');
+        component2.setAttribute('id', 'component2');
+        document.body.appendChild(component2);
 
-				let renderCallCount = 0;
-				const originalRenderNestedComponent = oc.renderNestedComponent;
+        let renderCallCount = 0;
+        const originalRenderNestedComponent = oc.renderNestedComponent;
 
-				oc.renderNestedComponent = (component, callback) => {
-					renderCallCount++;
-					component.setAttribute("data-rendered", "true");
-					callback();
-				};
+        oc.renderNestedComponent = (component, callback) => {
+          renderCallCount++;
+          component.setAttribute('data-rendered', 'true');
+          callback();
+        };
 
-				oc.renderUnloadedComponents();
+        oc.renderUnloadedComponents();
 
-				setTimeout(() => {
-					oc.renderNestedComponent = originalRenderNestedComponent;
-					resolve({
-						renderCallCount,
-						component1HasDataRendered: component1.hasAttribute("data-rendered"),
-						component2HasDataRendered: component2.hasAttribute("data-rendered"),
-					});
-				}, 100);
-			});
-		});
+        setTimeout(() => {
+          oc.renderNestedComponent = originalRenderNestedComponent;
+          resolve({
+            renderCallCount,
+            component1HasDataRendered: component1.hasAttribute('data-rendered'),
+            component2HasDataRendered: component2.hasAttribute('data-rendered')
+          });
+        }, 100);
+      });
+    });
 
-		expect(result.renderCallCount).toBeGreaterThan(0);
-		expect(result.component1HasDataRendered).toBe(true);
-		expect(result.component2HasDataRendered).toBe(true);
-	});
+    expect(result.renderCallCount).toBeGreaterThan(0);
+    expect(result.component1HasDataRendered).toBe(true);
+    expect(result.component2HasDataRendered).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Partial fix for #1515 focused on the browser client only.

`oc.build` no longer forces a trailing slash on the generated component href. Hrefs go from `.../name/version/` to `.../name/version`, while still tolerating a `baseUrl` that already ends in `/`.

This is safe because:
- Registry component routes are already registered without a trailing slash
- Server-side `urlBuilder.component()` already emits no-slash URLs
- `oc.renderByHref` uses the href as-is and does not depend on a final `/`

### In scope
- `oc-client-browser` `oc.build` URL construction
- Unit/Playwright coverage for no trailing slash (with/without version, baseUrl trailing slash, params)
- Docs example update
- Changeset for `oc-client-browser` (minor)

### Out of scope (still tracked in #1515)
- Fastify adapter `ignoreTrailingSlash` option + default flip to `false`
- Registry router route normalization / root redirect
- Server-side `componentPreview` URL builder (`.../~preview/`)
- Express adapter behavior
- CDN/cache-key migration for previously emitted trailing-slash URLs

Fixes nothing end-to-end by itself for Fastify operators — it removes one first-party trailing-slash emitter so later registry/adapter work can default to strict routing safely.

#### Test plan
- [x] `cd packages/oc-client-browser && npm test` (244/244 passed)
- [x] Assertions pin no trailing slash when baseUrl ends with `/` and when version is present/absent

Does not close #1515 — leave it open until the remaining work lands.

Generated with [Devin](https://devin.ai)