### PR TITLE
perf: reduce component route burst overhead

### DIFF
--- a/packages/oc-fastify-server-adapter/src/index.ts
+++ b/packages/oc-fastify-server-adapter/src/index.ts
@@ -225,6 +225,7 @@ class FastifyHttpServerAdapter implements HttpServerAdapter<FastifyInstance> {
     this.app.addHook('preHandler', async (request) => {
       const req = request as FastifyRequestWithState;
       if (
+        req.method !== 'PUT' ||
         req[multipartParsedSym] ||
         typeof req.isMultipart !== 'function' ||
         !req.isMultipart()

--- a/packages/oc-fastify-server-adapter/test/index.test.ts
+++ b/packages/oc-fastify-server-adapter/test/index.test.ts
@@ -337,6 +337,32 @@ test('returns 404 for empty handler arrays and scopes allow headers to matching 
   await closeAdapter(adapter);
 });
 
+test('skips multipart parsing for non-publish methods', async () => {
+  const adapter = createFastifyAdapter();
+  const app = asFastify(adapter);
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'oc-fastify-adapter-'));
+  const filename = jest.fn((originalName: string) => originalName);
+
+  adapter.enableFileUploads({ filename, tempDir });
+  adapter.route('post', '/components', 'components', [
+    (_req, res) => res.json({})
+  ]);
+  await app.ready();
+
+  const response = await app.inject({
+    headers: { 'content-type': 'multipart/form-data; boundary=unused' },
+    method: 'POST',
+    payload: '--unused--\r\n',
+    url: '/components'
+  });
+
+  expect(response.statusCode).toBe(200);
+  expect(filename).not.toHaveBeenCalled();
+
+  await closeAdapter(adapter);
+  await rm(tempDir, { force: true, recursive: true });
+});
+
 test('normalises multipart uploads into OC files and body fields', async () => {
   const adapter = createFastifyAdapter();
   const app = asFastify(adapter);

--- a/packages/oc/src/registry/domain/events-handler.ts
+++ b/packages/oc/src/registry/domain/events-handler.ts
@@ -50,6 +50,7 @@ type Events = {
 
 type EventsHandler = {
   fire<T extends keyof Events>(eventName: T, data: Events[T]): void;
+  hasListeners<T extends keyof Events>(eventName: T): boolean;
   on<T extends keyof Events>(
     eventName: T,
     listener: Subscription<Events[T]>
@@ -68,6 +69,10 @@ const eventsHandler: EventsHandler = {
         callback(eventData);
       }
     }
+  },
+
+  hasListeners(eventName: string): boolean {
+    return Boolean(subscriptions[eventName]?.length);
   },
 
   on(eventName: string, callback: Subscription): void {

--- a/packages/oc/src/registry/domain/http-server/express-adapter.ts
+++ b/packages/oc/src/registry/domain/http-server/express-adapter.ts
@@ -102,7 +102,13 @@ class ExpressHttpServerAdapter implements HttpServerAdapter<Express> {
       })
     });
 
-    this.app.use(upload.any());
+    const parseUpload = upload.any();
+    this.app.use((req, res, next) => {
+      if (req.method !== 'PUT') {
+        return next();
+      }
+      parseUpload(req, res, next);
+    });
   }
 
   enableRequestTiming(

--- a/packages/oc/src/registry/domain/nested-renderer.ts
+++ b/packages/oc/src/registry/domain/nested-renderer.ts
@@ -1,6 +1,7 @@
 import strings from '../../resources';
 import settings from '../../resources/settings';
 import type { Config } from '../../types';
+import pLimit from '../../utils/pLimit';
 import type {
   GetComponentResult,
   RendererOptions
@@ -65,23 +66,26 @@ export default function nestedRenderer(
         );
       }
 
+      const limit = pLimit(10);
       return Promise.all(
-        components.map((component) => {
-          return renderer({
-            conf: conf,
-            headers: {
-              ...options.headers,
-              accept: settings.registry.acceptRenderedHeader
-            },
-            ip: component.ip || '',
-            name: component.name!,
-            parameters: {
-              ...options.parameters,
-              ...component.parameters
-            },
-            version: component.version || ''
-          }).catch((err) => new Error(err));
-        })
+        components.map((component) =>
+          limit(() =>
+            renderer({
+              conf: conf,
+              headers: {
+                ...options.headers,
+                accept: settings.registry.acceptRenderedHeader
+              },
+              ip: component.ip || '',
+              name: component.name!,
+              parameters: {
+                ...options.parameters,
+                ...component.parameters
+              },
+              version: component.version || ''
+            }).catch((err) => new Error(err))
+          )
+        )
       );
     }
   };

--- a/packages/oc/src/registry/domain/validators/plugins-requirements.ts
+++ b/packages/oc/src/registry/domain/validators/plugins-requirements.ts
@@ -12,18 +12,19 @@ export default function pluginsRequirements(
     | string[]
     | null
     | undefined,
-  registryPlugins: Config['plugins']
+  registryPlugins: Config['plugins'] | ReadonlySet<string>
 ): ValidationResult {
   const missing: string[] = [];
   const requiredPlugins = Array.isArray(componentRequirements)
     ? componentRequirements
     : Object.keys(componentRequirements || {});
+  const registryPluginNames =
+    registryPlugins instanceof Set
+      ? registryPlugins
+      : new Set(Object.keys(registryPlugins || {}));
 
   for (const requiredPlugin of requiredPlugins) {
-    if (
-      !registryPlugins ||
-      !Object.keys(registryPlugins).includes(requiredPlugin)
-    ) {
+    if (!registryPluginNames.has(requiredPlugin)) {
       missing.push(requiredPlugin);
     }
   }

--- a/packages/oc/src/registry/domain/version-handler.ts
+++ b/packages/oc/src/registry/domain/version-handler.ts
@@ -5,16 +5,19 @@ export function getAvailableVersion(
   requestedVersion: string | undefined,
   availableVersions: string[]
 ): string | undefined {
-  if (typeof requestedVersion === 'undefined') {
-    requestedVersion = '';
+  if (!requestedVersion) {
+    return (
+      semver.maxSatisfying(availableVersions, '') ||
+      semverExtra.max(availableVersions) ||
+      undefined
+    );
   }
 
-  const version =
-    semver.maxSatisfying(availableVersions, requestedVersion) || undefined;
-  const max = semverExtra.max(availableVersions);
-  const isLatest = requestedVersion === '';
+  if (availableVersions.includes(requestedVersion)) {
+    return requestedVersion;
+  }
 
-  return version || (isLatest && max) || undefined;
+  return semver.maxSatisfying(availableVersions, requestedVersion) || undefined;
 }
 
 export function validateNewVersion(

--- a/packages/oc/src/registry/middleware/index.ts
+++ b/packages/oc/src/registry/middleware/index.ts
@@ -17,6 +17,10 @@ export const bind = (
   });
 
   adapter.enableRequestTiming((req, res, time) => {
+    if (!eventsHandler.hasListeners('request')) {
+      return;
+    }
+
     const data: RequestData = {
       body: req.body,
       duration: time,

--- a/packages/oc/src/registry/routes/components.ts
+++ b/packages/oc/src/registry/routes/components.ts
@@ -1,6 +1,6 @@
-import async from 'async';
 import strings from '../../resources';
 import type { Config } from '../../types';
+import pLimit from '../../utils/pLimit';
 import type {
   CookieOptions,
   OcHandler,
@@ -86,47 +86,55 @@ export default function components(
       }
     }
 
-    async.map(
-      components,
-      (component, callback) => {
-        getComponent(
-          {
-            conf: res.conf,
-            action: component.action,
-            name: component.name,
-            headers: req.headers,
-            ip: req.ip!,
-            omitHref: !!req.body.omitHref,
-            parameters: { ...req.body.parameters, ...component.parameters },
-            version: component.version
-          },
-          (result) => callback(null, result)
-        );
-      },
-      // @ts-expect-error
-      (_err: any, results: GetComponentResult[]) => {
-        try {
-          setHeaders(results, res);
-          setCookies(results, res);
-          res.status(200).json(results);
-        } catch (e) {
-          // @ts-expect-error I think this will never reach (how can setHeaders throw?)
-          if (results.code && results.error) {
-            // @ts-expect-error
-            res.status(500).json({ code: results.code, error: results.error });
-          } else {
-            res.status(500).json({
-              code: 'RENDER_ERROR',
-              error: strings.errors.registry.RENDER_ERROR(
-                results
-                  .map((x) => `${x.response.name}@${x.response.version}`)
-                  .join(', '),
-                String(e)
-              )
-            });
-          }
-        }
+    const limit = pLimit(10);
+    Promise.all(
+      components.map((component) =>
+        limit(
+          () =>
+            new Promise<GetComponentResult>((resolve) => {
+              getComponent(
+                {
+                  conf: res.conf,
+                  action: component.action,
+                  name: component.name,
+                  headers: req.headers,
+                  ip: req.ip!,
+                  omitHref: !!req.body.omitHref,
+                  parameters: {
+                    ...req.body.parameters,
+                    ...component.parameters
+                  },
+                  version: component.version
+                },
+                resolve
+              );
+            })
+        )
+      )
+    ).then((results) => {
+      try {
+        setHeaders(results, res);
+        setCookies(results, res);
+        res
+          .status(200)
+          .json(
+            results.map((result) =>
+              result.response.renderMode && !result.headers
+                ? { ...result, headers: {} }
+                : result
+            )
+          );
+      } catch (e) {
+        res.status(500).json({
+          code: 'RENDER_ERROR',
+          error: strings.errors.registry.RENDER_ERROR(
+            results
+              .map((x) => `${x.response.name}@${x.response.version}`)
+              .join(', '),
+            String(e)
+          )
+        });
       }
-    );
+    });
   };
 }

--- a/packages/oc/src/registry/routes/helpers/get-component.ts
+++ b/packages/oc/src/registry/routes/helpers/get-component.ts
@@ -51,6 +51,7 @@ export interface GetComponentResult {
     error?: unknown;
     version?: string;
     html?: string;
+    renderMode?: string;
     requestVersion?: string;
     name?: string;
     details?: {
@@ -140,6 +141,41 @@ export default function getComponent(conf: Config, repository: Repository) {
     refreshInterval: conf.refreshInterval
   });
   const convertPlugins = pluginConverter(conf.plugins);
+  const customHeadersByConfig = new WeakMap<Config, Set<string> | undefined>();
+  const pluginNamesByConfig = new WeakMap<Config, Set<string>>();
+  const getCustomHeadersToSkip = (config: Config) => {
+    if (!customHeadersByConfig.has(config)) {
+      customHeadersByConfig.set(
+        config,
+        config.customHeadersToSkipOnWeakVersion?.length
+          ? new Set(config.customHeadersToSkipOnWeakVersion)
+          : undefined
+      );
+    }
+    return customHeadersByConfig.get(config);
+  };
+  const getRegistryPluginNames = (config: Config) => {
+    let names = pluginNamesByConfig.get(config);
+    if (!names) {
+      names = new Set(Object.keys(config.plugins || {}));
+      pluginNamesByConfig.set(config, names);
+    }
+    return names;
+  };
+  const inFlight = new Map<string, Promise<unknown>>();
+
+  const singleFlight = <T>(key: string, operation: () => Promise<T>) => {
+    const pending = inFlight.get(key) as Promise<T> | undefined;
+    if (pending) {
+      return pending;
+    }
+
+    const promise = operation().finally(() => {
+      inFlight.delete(key);
+    });
+    inFlight.set(key, promise);
+    return promise;
+  };
 
   const getEnv = async (
     component: Component
@@ -149,12 +185,13 @@ export default function getComponent(conf: Config, repository: Repository) {
 
     if (cached) return cached;
 
-    const env = component.oc.files.env
-      ? await repository.getEnv(component.name, component.version)
-      : {};
-    cache.set('file-contents', cacheKey, env);
-
-    return env;
+    return singleFlight(cacheKey, async () => {
+      const env = component.oc.files.env
+        ? await repository.getEnv(component.name, component.version)
+        : {};
+      cache.set('file-contents', cacheKey, env);
+      return env;
+    });
   };
 
   const renderer = async (
@@ -163,7 +200,7 @@ export default function getComponent(conf: Config, repository: Repository) {
   ) => {
     const nestedRenderer = NestedRenderer(renderer, options.conf);
     const retrievingInfo = GetComponentRetrievingInfo(options);
-    let responseHeaders: Record<string, string> = {};
+    let responseHeaders: Record<string, string> | undefined;
     const responseCookies: Array<{
       name: string;
       value: any;
@@ -196,11 +233,8 @@ export default function getComponent(conf: Config, repository: Repository) {
     };
 
     let componentCallbackDone = false;
+    let callbackTimeout: ReturnType<typeof setTimeout> | undefined;
     const conf = options.conf;
-    const customHeadersToSkipSet = conf.customHeadersToSkipOnWeakVersion?.length
-      ? new Set(conf.customHeadersToSkipOnWeakVersion)
-      : undefined;
-    const acceptLanguage = getLanguage();
     const requestedComponent = {
       name: options.name,
       version: options.version || '',
@@ -247,7 +281,7 @@ export default function getComponent(conf: Config, repository: Repository) {
         // check component requirements are satisfied by registry
         const pluginsCompatibility = validator.validatePluginsRequirements(
           component.oc.plugins,
-          conf.plugins
+          getRegistryPluginNames(conf)
         );
 
         if (!pluginsCompatibility.isValid) {
@@ -325,11 +359,16 @@ export default function getComponent(conf: Config, repository: Repository) {
         }
 
         const filterCustomHeaders = (
-          headers: Record<string, string>,
+          headers: Record<string, string> | undefined,
           requestedVersion: string,
           actualVersion: string
         ) => {
-          if (!customHeadersToSkipSet || requestedVersion === actualVersion) {
+          const customHeadersToSkipSet = getCustomHeadersToSkip(conf);
+          if (
+            !headers ||
+            !customHeadersToSkipSet ||
+            requestedVersion === actualVersion
+          ) {
             return headers;
           }
 
@@ -341,7 +380,7 @@ export default function getComponent(conf: Config, repository: Repository) {
             }
           }
 
-          return filteredHeaders || {};
+          return filteredHeaders;
         };
 
         const returnComponent = async (err: any, data: any) => {
@@ -349,6 +388,10 @@ export default function getComponent(conf: Config, repository: Repository) {
             return;
           }
           componentCallbackDone = true;
+          if (callbackTimeout) {
+            clearTimeout(callbackTimeout);
+            callbackTimeout = undefined;
+          }
 
           const componentHref = urlBuilder.component(
             {
@@ -362,20 +405,19 @@ export default function getComponent(conf: Config, repository: Repository) {
           const isUnrendered =
             options.headers.accept === settings.registry.acceptUnrenderedHeader;
 
-          const isValidClientRequest =
-            options.headers['user-agent'] &&
-            !!options.headers['user-agent'].match('oc-client-');
-
-          const supportedTemplates = options.headers['templates']
-            ? parseTemplatesHeader(options.headers['templates'] as string)
-            : [];
-
-          const isTemplateSupportedByClient = Boolean(
-            isValidClientRequest &&
-              options.headers['templates'] &&
-              (supportedTemplates.includes(component.oc.files.template.type) ||
-                supportedTemplates.includes(templateType))
-          );
+          const isValidClientRequest = String(
+            options.headers['user-agent'] || ''
+          ).includes('oc-client-');
+          const templatesHeader = options.headers['templates'];
+          let isTemplateSupportedByClient = false;
+          if (isUnrendered && isValidClientRequest && templatesHeader) {
+            const supportedTemplates = parseTemplatesHeader(
+              templatesHeader as string
+            );
+            isTemplateSupportedByClient =
+              supportedTemplates.includes(component.oc.files.template.type) ||
+              supportedTemplates.includes(templateType);
+          }
 
           let renderMode = options.action ? 'unrendered' : 'rendered';
           if (isUnrendered) {
@@ -481,7 +523,7 @@ export default function getComponent(conf: Config, repository: Repository) {
           if (renderMode === 'unrendered') {
             callback({
               status: 200,
-              headers: responseHeaders,
+              ...(responseHeaders ? { headers: responseHeaders } : {}),
               response: Object.assign(response, {
                 data: data,
                 template: {
@@ -530,7 +572,7 @@ export default function getComponent(conf: Config, repository: Repository) {
 
                   callback({
                     status: 200,
-                    headers: responseHeaders,
+                    ...(responseHeaders ? { headers: responseHeaders } : {}),
                     response: Object.assign(response, { html })
                   });
                 }
@@ -540,17 +582,29 @@ export default function getComponent(conf: Config, repository: Repository) {
             if (cached && !conf.hotReloading) {
               returnResult(cached);
             } else {
-              fromPromise(repository.getCompiledView)(
-                component.name,
-                component.version,
-                (_err, templateText) => {
-                  const template = ocTemplate.getCompiledTemplate(
-                    templateText,
-                    key
-                  );
-                  cache.set('file-contents', cacheKey, template);
-                  returnResult(template);
-                }
+              const loadTemplate = async () => {
+                const templateText = await repository.getCompiledView(
+                  component.name,
+                  component.version
+                );
+                const template = ocTemplate.getCompiledTemplate(
+                  templateText,
+                  key
+                );
+                cache.set('file-contents', cacheKey, template);
+                return template;
+              };
+              const templatePromise = conf.hotReloading
+                ? loadTemplate()
+                : singleFlight(cacheKey, loadTemplate);
+              templatePromise.then(returnResult).catch((error) =>
+                callback({
+                  status: 500,
+                  response: {
+                    code: 'INTERNAL_SERVER_ERROR',
+                    error
+                  }
+                })
               );
             }
           }
@@ -586,9 +640,17 @@ export default function getComponent(conf: Config, repository: Repository) {
             const domain = Domain.create();
             const setEmptyResponse =
               emptyResponseHandler.contextDecorator(returnComponent);
+            let parsedAcceptLanguage:
+              | ReturnType<typeof acceptLanguageParser.parse>
+              | undefined;
             const contextObj = {
               action: options.action,
-              acceptLanguage: acceptLanguageParser.parse(acceptLanguage!),
+              get acceptLanguage() {
+                parsedAcceptLanguage ??= acceptLanguageParser.parse(
+                  getLanguage()!
+                );
+                return parsedAcceptLanguage;
+              },
               baseUrl: conf.baseUrl,
               env: { ...conf.env, ...env },
               params,
@@ -633,7 +695,7 @@ export default function getComponent(conf: Config, repository: Repository) {
             const setCallbackTimeout = () => {
               const executionTimeout = conf.executionTimeout;
               if (executionTimeout) {
-                setTimeout(() => {
+                callbackTimeout = setTimeout(() => {
                   const message = `timeout (${executionTimeout * 1000}ms)`;
                   returnComponent({ message }, undefined);
                   domain.exit();
@@ -646,103 +708,105 @@ export default function getComponent(conf: Config, repository: Repository) {
 
               try {
                 domain.run(() => {
-                  cached(contextObj, returnComponent);
                   setCallbackTimeout();
+                  cached(contextObj, returnComponent);
                 });
               } catch (e) {
                 return returnComponent(e, undefined);
               }
             } else {
-              fromPromise(repository.getDataProvider)(
-                component.name,
-                component.version,
-                (err, dataProvider) => {
-                  if (err) {
-                    componentCallbackDone = true;
-
-                    return callback({
-                      status: 502,
-                      response: {
-                        code: 'DATA_RESOLVING_ERROR',
-                        error: strings.errors.registry.RESOLVING_ERROR
-                      }
-                    });
-                  }
-
-                  const context = {
-                    require: RequireWrapper(conf.dependencies),
-                    module: {
-                      exports: {} as Record<string, (...args: any[]) => any>
-                    },
-                    exports: {} as Record<string, (...args: any[]) => any>,
-                    console: conf.local ? console : noopConsole,
-                    setTimeout,
-                    Buffer,
-                    Error,
-                    AbortController: globalThis?.AbortController,
-                    AbortSignal: globalThis?.AbortSignal,
-                    Promise,
-                    Date,
-                    Symbol,
-                    eval: undefined,
-                    URL: globalThis?.URL,
-                    URLSearchParams: globalThis?.URLSearchParams,
-                    crypto: globalThis?.crypto,
-                    fetch: globalThis?.fetch,
-                    process: {
-                      env: {
-                        NODE_ENV: conf.local ? 'development' : 'production',
-                        ...conf.env,
-                        ...env
-                      }
+              const handleError = (err: {
+                code: string;
+                missing: string[];
+              }) => {
+                if (err.code === 'DATA_RESOLVING_ERROR') {
+                  componentCallbackDone = true;
+                  return callback({
+                    status: 502,
+                    response: {
+                      code: err.code,
+                      error: strings.errors.registry.RESOLVING_ERROR
                     }
-                  };
-
-                  const handleError = (err: {
-                    code: string;
-                    missing: string[];
-                  }) => {
-                    if (err.code === 'DEPENDENCY_MISSING_FROM_REGISTRY') {
-                      componentCallbackDone = true;
-
-                      return callback({
-                        status: 501,
-                        response: {
-                          code: err.code,
-                          error: strings.errors.registry.DEPENDENCY_NOT_FOUND(
-                            err.missing.join(', ')
-                          ),
-                          missingDependencies: err.missing
-                        }
-                      });
-                    }
-
-                    returnComponent(err, undefined);
-                  };
-
-                  const options = conf.local
-                    ? {
-                        displayErrors: true,
-                        filename: dataProvider.filePath
-                      }
-                    : {};
-
-                  try {
-                    vm.runInNewContext(dataProvider.content, context, options);
-                    const processData =
-                      context.module.exports['data'] || context.exports['data'];
-                    cache.set('file-contents', cacheKey, processData);
-
-                    domain.on('error', handleError);
-                    domain.run(() => {
-                      processData(contextObj, returnComponent);
-                      setCallbackTimeout();
-                    });
-                  } catch (err) {
-                    handleError(err as any);
-                  }
+                  });
                 }
-              );
+
+                if (err.code === 'DEPENDENCY_MISSING_FROM_REGISTRY') {
+                  componentCallbackDone = true;
+                  return callback({
+                    status: 501,
+                    response: {
+                      code: err.code,
+                      error: strings.errors.registry.DEPENDENCY_NOT_FOUND(
+                        err.missing.join(', ')
+                      ),
+                      missingDependencies: err.missing
+                    }
+                  });
+                }
+
+                returnComponent(err, undefined);
+              };
+
+              const loadDataProvider = async () => {
+                const dataProvider = await repository
+                  .getDataProvider(component.name, component.version)
+                  .catch(() => {
+                    throw { code: 'DATA_RESOLVING_ERROR', missing: [] };
+                  });
+                const context = {
+                  require: RequireWrapper(conf.dependencies),
+                  module: {
+                    exports: {} as Record<string, (...args: any[]) => any>
+                  },
+                  exports: {} as Record<string, (...args: any[]) => any>,
+                  console: conf.local ? console : noopConsole,
+                  setTimeout,
+                  Buffer,
+                  Error,
+                  AbortController: globalThis?.AbortController,
+                  AbortSignal: globalThis?.AbortSignal,
+                  Promise,
+                  Date,
+                  Symbol,
+                  eval: undefined,
+                  URL: globalThis?.URL,
+                  URLSearchParams: globalThis?.URLSearchParams,
+                  crypto: globalThis?.crypto,
+                  fetch: globalThis?.fetch,
+                  process: {
+                    env: {
+                      NODE_ENV: conf.local ? 'development' : 'production',
+                      ...conf.env,
+                      ...env
+                    }
+                  }
+                };
+                const vmOptions = conf.local
+                  ? {
+                      displayErrors: true,
+                      filename: dataProvider.filePath
+                    }
+                  : {};
+
+                vm.runInNewContext(dataProvider.content, context, vmOptions);
+                const processData =
+                  context.module.exports['data'] || context.exports['data'];
+                cache.set('file-contents', cacheKey, processData);
+                return processData;
+              };
+
+              const dataProviderPromise = conf.hotReloading
+                ? loadDataProvider()
+                : singleFlight(cacheKey, loadDataProvider);
+              dataProviderPromise
+                .then((processData) => {
+                  domain.on('error', handleError);
+                  domain.run(() => {
+                    setCallbackTimeout();
+                    processData(contextObj, returnComponent);
+                  });
+                })
+                .catch(handleError);
             }
           });
         }

--- a/packages/oc/tasks/benchmarks/server-benchmark.js
+++ b/packages/oc/tasks/benchmarks/server-benchmark.js
@@ -13,6 +13,16 @@ const getPortAsync = promisify(getPort);
 const DEFAULT_OUT_DIR = path.resolve('test/results/benchmarks');
 const DEFAULT_REPETITIONS = 5;
 const DEFAULT_HEADERS = ['Accept: application/json'];
+const BATCH_SOURCE_COMPONENTS = [
+  'hello-world',
+  'no-containers',
+  'empty',
+  'language',
+  'lodash-component'
+];
+const BATCH_COMPONENT_NAMES = BATCH_SOURCE_COMPONENTS.flatMap((name) =>
+  Array.from({ length: 4 }, (_, index) => `${name}-benchmark-${index + 1}`)
+);
 
 const parseInteger = (value, fallback) => {
   const parsed = Number.parseInt(String(value), 10);
@@ -99,6 +109,21 @@ const copyDirectory = async (source, destination) => {
 const readJson = async (filePath) =>
   JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
 
+const ensurePackaged = async (componentPath) => {
+  const packagePath = path.join(componentPath, '_package', 'package.json');
+  try {
+    await fs.promises.access(packagePath);
+  } catch {
+    await new Promise((resolve, reject) => {
+      oc.cli.package({ componentPath, compress: false }, (error) => {
+        if (error) return reject(error);
+        resolve();
+      });
+    });
+  }
+  return path.join(componentPath, '_package');
+};
+
 const calculatePercentageChange = (current, baseline) => {
   if (baseline === 0) return current > 0 ? 100 : 0;
   return ((current - baseline) / baseline) * 100;
@@ -134,11 +159,24 @@ const compareWithBaseline = (current, baseline) => {
         change: calculatePercentageChange(currentAggregate.latencyP95Ms.average, baselineAggregate.latencyP95Ms.average),
         improved: currentAggregate.latencyP95Ms.average < baselineAggregate.latencyP95Ms.average
       },
-      latencyMeanMs: {
-        current: currentAggregate.latencyMeanMs.average,
-        baseline: baselineAggregate.latencyMeanMs.average,
-        change: calculatePercentageChange(currentAggregate.latencyMeanMs.average, baselineAggregate.latencyMeanMs.average),
-        improved: currentAggregate.latencyMeanMs.average < baselineAggregate.latencyMeanMs.average
+      latencyP99Ms: {
+        current:
+          currentAggregate.latencyP99Ms?.average ??
+          currentAggregate.latencyMeanMs.average,
+        baseline:
+          baselineAggregate.latencyP99Ms?.average ??
+          baselineAggregate.latencyMeanMs.average,
+        change: calculatePercentageChange(
+          currentAggregate.latencyP99Ms?.average ??
+            currentAggregate.latencyMeanMs.average,
+          baselineAggregate.latencyP99Ms?.average ??
+            baselineAggregate.latencyMeanMs.average
+        ),
+        improved:
+          (currentAggregate.latencyP99Ms?.average ??
+            currentAggregate.latencyMeanMs.average) <
+          (baselineAggregate.latencyP99Ms?.average ??
+            baselineAggregate.latencyMeanMs.average)
       },
       successRate: {
         current: currentAggregate.successRate.average,
@@ -187,7 +225,7 @@ const printComparison = (comparison) => {
     
     console.log(`  ${rpsStatus} RPS: ${metrics.rps.current.toFixed(2)} vs ${metrics.rps.baseline.toFixed(2)} (${formatPercentageChange(metrics.rps.change)})`);
     console.log(`  ${latencyStatus} P95 Latency: ${metrics.latencyP95Ms.current.toFixed(2)}ms vs ${metrics.latencyP95Ms.baseline.toFixed(2)}ms (${formatPercentageChange(metrics.latencyP95Ms.change)})`);
-    console.log(`  P99 Latency: ${metrics.latencyMeanMs.current.toFixed(2)}ms vs ${metrics.latencyMeanMs.baseline.toFixed(2)}ms (${formatPercentageChange(metrics.latencyMeanMs.change)})`);
+    console.log(`  P99 Latency: ${metrics.latencyP99Ms.current.toFixed(2)}ms vs ${metrics.latencyP99Ms.baseline.toFixed(2)}ms (${formatPercentageChange(metrics.latencyP99Ms.change)})`);
     console.log(`  Success Rate: ${(metrics.successRate.current * 100).toFixed(2)}% vs ${(metrics.successRate.baseline * 100).toFixed(2)}% (${formatPercentageChange(metrics.successRate.change)})`);
     
     if (metrics.memory) {
@@ -205,26 +243,42 @@ const prepareStorageFixtures = async () => {
   );
   const componentsDir = path.join(root, 'components');
 
+  const batchSources = new Map();
+  for (const name of BATCH_SOURCE_COMPONENTS) {
+    const componentPath = path.resolve('test/fixtures/components', name);
+    batchSources.set(name, await ensurePackaged(componentPath));
+  }
+
   const componentsToCopy = [
     {
       name: 'welcome-with-plugin',
-      packagePath: path.resolve(
-        'test/fixtures/benchmark-components/welcome-with-plugin/_package/package.json'
-      ),
-      source: path.resolve('test/fixtures/benchmark-components/welcome-with-plugin/_package')
+      source: path.resolve(
+        'test/fixtures/benchmark-components/welcome-with-plugin/_package'
+      )
     },
+    ...BATCH_COMPONENT_NAMES.map((name) => {
+      const sourceName = BATCH_SOURCE_COMPONENTS.find((candidate) =>
+        name.startsWith(`${candidate}-benchmark-`)
+      );
+      return { name, source: batchSources.get(sourceName), rewriteName: true };
+    }),
     {
       name: 'oc-client',
-      packagePath: path.resolve('dist/components/oc-client/_package/package.json'),
       source: path.resolve('dist/components/oc-client/_package')
     }
   ];
 
   for (const component of componentsToCopy) {
-    const pkg = await readJson(component.packagePath);
+    const pkg = await readJson(path.join(component.source, 'package.json'));
     const version = pkg.version;
     const destination = path.join(componentsDir, component.name, version);
     await copyDirectory(component.source, destination);
+    if (component.rewriteName) {
+      await writeJson(path.join(destination, 'package.json'), {
+        ...pkg,
+        name: component.name
+      });
+    }
   }
 
   return {
@@ -263,6 +317,9 @@ const runBombardier = ({ url, options }) =>
     }
     for (const header of options.headers || []) {
       args.push('-H', header);
+    }
+    if (options.body) {
+      args.push('-b', options.body);
     }
     args.push(url);
 
@@ -314,6 +371,7 @@ const aggregate = (runs) => {
 
   const rps = metric((m) => m.rpsMean);
   const latencyP95Ms = metric((m) => m.latencyP95Ms);
+  const latencyP99Ms = metric((m) => m.latencyP99Ms);
   const latencyMeanMs = metric((m) => m.latencyMeanMs);
   const successRate = metric((m) => m.successRate);
 
@@ -328,6 +386,11 @@ const aggregate = (runs) => {
       average: average(latencyP95Ms),
       min: min(latencyP95Ms),
       max: max(latencyP95Ms)
+    },
+    latencyP99Ms: {
+      average: average(latencyP99Ms),
+      min: min(latencyP99Ms),
+      max: max(latencyP99Ms)
     },
     latencyMeanMs: {
       average: average(latencyMeanMs),
@@ -392,6 +455,7 @@ const startRegistry = async (scenario, options) => {
   };
 
   let registryOptions;
+  let storageAdapter;
   let disposeFixtures = async () => {};
   if (scenario === 'local-memory' || scenario === 'high-load-local') {
     registryOptions = {
@@ -400,7 +464,11 @@ const startRegistry = async (scenario, options) => {
       hotReloading: false,
       path: path.resolve('test/fixtures/components')
     };
-  } else if (scenario === 'storage-simulated' || scenario === 'high-load-storage') {
+  } else if (
+    scenario === 'storage-simulated' ||
+    scenario === 'high-load-storage' ||
+    scenario === 'batch-storage'
+  ) {
     const preparedFixtures = await prepareStorageFixtures();
     const fixturesRoot = preparedFixtures.root;
     const componentsDir = preparedFixtures.componentsDir;
@@ -410,20 +478,22 @@ const startRegistry = async (scenario, options) => {
       ...commonOptions,
       local: false,
       storage: {
-        adapter: (storageOptions) =>
-          createStorageAdapter({
+        adapter: (storageOptions) => {
+          storageAdapter = createStorageAdapter({
             ...storageOptions,
             fixturesRoot,
             minLatencyMs: options.storageMinLatencyMs,
             maxLatencyMs: options.storageMaxLatencyMs,
             maxConcurrentRequests: options.storageMaxConcurrentRequests
-          }),
+          });
+          return storageAdapter;
+        },
         options: {
           componentsDir,
           fixturesRoot
         }
       },
-      dependencies: []
+      dependencies: ['lodash.isequal']
     };
   } else {
     throw new Error(`Unknown scenario: ${scenario}`);
@@ -448,6 +518,8 @@ const startRegistry = async (scenario, options) => {
   return {
     registry,
     baseUrl,
+    getStorageMetrics: () => storageAdapter?.getMetrics(),
+    resetStorageMetrics: () => storageAdapter?.resetMetrics(),
     close: async () => {
       await new Promise((resolve, reject) => {
         registry.close((error) => {
@@ -470,6 +542,19 @@ const buildScenarios = () => [
     key: 'storage-simulated',
     title: 'Simulated storage path + plugin execution',
     urlPath: '/welcome-with-plugin/1.0.0?firstName=Jane&lastName=Doe&suffix=-Bench'
+  },
+  {
+    key: 'batch-storage',
+    title: 'Batch route fan-out (simulated storage)',
+    urlPath: '/',
+    method: 'POST',
+    headers: ['Content-Type: application/json'],
+    body: JSON.stringify({
+      components: BATCH_COMPONENT_NAMES.map((name) => ({
+        name,
+        version: '1.0.0'
+      }))
+    })
   },
   {
     key: 'high-load-local',
@@ -497,45 +582,77 @@ const benchmarkScenario = async ({ scenario, options }) => {
   const server = await startRegistry(scenario.key, options);
   const url = `${server.baseUrl.replace(/\/$/, '')}${scenario.urlPath}`;
   const resourceMeasurements = [];
+  const storageMeasurements = [];
 
   try {
+    if (scenario.body) {
+      const response = await fetch(url, {
+        method: scenario.method,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: scenario.body
+      });
+      const results = await response.json();
+      if (
+        !response.ok ||
+        !Array.isArray(results) ||
+        results.length !== BATCH_COMPONENT_NAMES.length ||
+        results.some((result) => result.status !== 200)
+      ) {
+        throw new Error(
+          `Batch fixture preflight failed: HTTP ${response.status} ${JSON.stringify(results)}`
+        );
+      }
+      console.log(
+        `[${scenario.key}] preflight: ${results.length} distinct components returned 200`
+      );
+    }
     for (let attempt = 1; attempt <= options.repetitions; attempt += 1) {
+      server.resetStorageMetrics();
       const monitoring = startResourceMonitoring();
-      
+
       const run = await runBombardier({
         url,
         options: {
           connections: options.connections,
           duration: options.duration,
           timeout: options.timeout,
-          method: 'GET',
+          method: scenario.method || 'GET',
+          body: scenario.body,
           requests: options.requests,
           rate: options.rate,
           disableKeepAlives: options.disableKeepAlives,
-          headers: options.headers
+          headers: [...options.headers, ...(scenario.headers || [])]
         }
       });
       
       const resourceDelta = monitoring.getDelta();
+      const storageMetrics = server.getStorageMetrics();
       resourceMeasurements.push(resourceDelta);
-      
+      if (storageMetrics) storageMeasurements.push(storageMetrics);
+
       const metrics = mapBombardierResult(run.raw.result);
       const runResult = {
         attempt,
         command: `bombardier ${run.args.join(' ')}`,
         metrics,
         rawResult: run.raw.result,
-        resourceUsage: resourceDelta
+        resourceUsage: resourceDelta,
+        storageMetrics
       };
 
       scenarioResult.runs.push(runResult);
 
       const rps = metrics.rpsMean.toFixed(2);
       const p95 = metrics.latencyP95Ms.toFixed(2);
+      const p99 = metrics.latencyP99Ms.toFixed(2);
       const mem = resourceDelta.memory.heapUsedDelta.toFixed(2);
       const ok = (metrics.successRate * 100).toFixed(2);
+      const storagePeak = storageMetrics?.peakConcurrentReads ?? 'n/a';
       console.log(
-        `[${scenario.key}] run ${attempt}/${options.repetitions} | rps=${rps} | p95=${p95}ms | mem=${mem}MB | success=${ok}%`
+        `[${scenario.key}] run ${attempt}/${options.repetitions} | rps=${rps} | p95=${p95}ms | p99=${p99}ms | mem=${mem}MB | storagePeak=${storagePeak} | success=${ok}%`
       );
     }
   } finally {
@@ -572,6 +689,16 @@ const benchmarkScenario = async ({ scenario, options }) => {
   };
   
   scenarioResult.resourceUsage = aggregateResourceUsage;
+  if (storageMeasurements.length) {
+    const peaks = storageMeasurements.map((metrics) =>
+      metrics.peakConcurrentReads
+    );
+    scenarioResult.storageConcurrency = {
+      average: peaks.reduce((sum, value) => sum + value, 0) / peaks.length,
+      min: Math.min(...peaks),
+      max: Math.max(...peaks)
+    };
+  }
   scenarioResult.aggregate = aggregate(scenarioResult.runs);
   return scenarioResult;
 };
@@ -702,13 +829,21 @@ const main = async () => {
     const aggregateResult = scenario.aggregate;
     const rps = aggregateResult.rps;
     const p95 = aggregateResult.latencyP95Ms;
+    const p99 = aggregateResult.latencyP99Ms;
     const success = aggregateResult.successRate;
     const resourceUsage = scenario.resourceUsage;
     
     console.log(
-      `\n[${scenario.key}] samples=${aggregateResult.samples} | rps(avg/min/max)=${rps.average.toFixed(2)}/${rps.min.toFixed(2)}/${rps.max.toFixed(2)} | p95ms(avg/min/max)=${p95.average.toFixed(2)}/${p95.min.toFixed(2)}/${p95.max.toFixed(2)} | success(avg)=${(success.average * 100).toFixed(2)}%`
+      `\n[${scenario.key}] samples=${aggregateResult.samples} | rps(avg/min/max)=${rps.average.toFixed(2)}/${rps.min.toFixed(2)}/${rps.max.toFixed(2)} | p95ms(avg/min/max)=${p95.average.toFixed(2)}/${p95.min.toFixed(2)}/${p95.max.toFixed(2)} | p99ms(avg/min/max)=${p99.average.toFixed(2)}/${p99.min.toFixed(2)}/${p99.max.toFixed(2)} | success(avg)=${(success.average * 100).toFixed(2)}%`
     );
     
+    if (scenario.storageConcurrency) {
+      const storage = scenario.storageConcurrency;
+      console.log(
+        `  Storage peak concurrency(avg/min/max)=${storage.average.toFixed(2)}/${storage.min}/${storage.max}`
+      );
+    }
+
     if (resourceUsage) {
       console.log(
         `  Memory: heapUsed(avg/min/max)=${resourceUsage.heapUsedDelta.average.toFixed(2)}/${resourceUsage.heapUsedDelta.min.toFixed(2)}/${resourceUsage.heapUsedDelta.max.toFixed(2)}MB | rss(avg/min/max)=${resourceUsage.rssDelta.average.toFixed(2)}/${resourceUsage.rssDelta.min.toFixed(2)}/${resourceUsage.rssDelta.max.toFixed(2)}MB`

--- a/packages/oc/tasks/benchmarks/single-flight-burst.js
+++ b/packages/oc/tasks/benchmarks/single-flight-burst.js
@@ -1,0 +1,281 @@
+const { spawnSync } = require('node:child_process');
+
+const WORKER_ENV = 'OC_SINGLE_FLIGHT_BURST_WORKER_N';
+const BURST_SIZES = [50, 200];
+const DOWNSTREAM_LATENCY_MS = 30;
+const MEMORY_SAMPLE_INTERVAL_MS = 1;
+const ENV_VALUE = 'single-flight-env-covered';
+const BYTES_PER_MB = 1024 * 1024;
+
+const writeAndExit = (value, exitCode) => {
+  process.stdout.write(`${JSON.stringify(value)}\n`, () => {
+    process.exit(exitCode);
+  });
+};
+
+const toMb = (bytes) => Number((Number(bytes || 0) / BYTES_PER_MB).toFixed(3));
+
+const memorySnapshot = () => {
+  const memory = process.memoryUsage();
+  return {
+    rssBytes: memory.rss,
+    heapUsedBytes: memory.heapUsed
+  };
+};
+
+const runParent = () => {
+  const results = BURST_SIZES.map((n) => {
+    const child = spawnSync(process.execPath, [__filename], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        [WORKER_ENV]: String(n)
+      },
+      maxBuffer: 1024 * 1024
+    });
+
+    if (child.error) throw child.error;
+    if (child.status !== 0) {
+      throw new Error(
+        [
+          `single-flight burst worker for N=${n} failed`,
+          `exit status: ${child.status}`,
+          child.stderr.trim(),
+          child.stdout.trim()
+        ]
+          .filter(Boolean)
+          .join('\n')
+      );
+    }
+
+    const output = child.stdout.trim();
+    if (!output) {
+      throw new Error(`single-flight burst worker for N=${n} returned no output`);
+    }
+    return JSON.parse(output);
+  });
+
+  writeAndExit(
+    {
+      benchmark: 'single-flight-cold-burst',
+      node: process.version,
+      platform: `${process.platform}-${process.arch}`,
+      fixedDownstreamLatencyMs: DOWNSTREAM_LATENCY_MS,
+      freshProcessPerBurst: true,
+      results
+    },
+    0
+  );
+};
+
+const runWorker = async (n) => {
+  if (!BURST_SIZES.includes(n)) {
+    throw new Error(
+      `invalid ${WORKER_ENV}: expected ${BURST_SIZES.join(' or ')}, got ${n}`
+    );
+  }
+
+  const GetComponentHelper = require(
+    '../../dist/registry/routes/helpers/get-component.js'
+  ).default;
+  const jadeTemplate = require('oc-template-jade');
+  const componentName = 'single-flight-burst-component';
+  const componentVersion = '1.0.0';
+  const templateHash = 'single-flight-burst-template';
+  const component = {
+    name: componentName,
+    version: componentVersion,
+    oc: {
+      container: false,
+      renderInfo: false,
+      files: {
+        template: {
+          type: 'jade',
+          hashKey: templateHash,
+          src: 'template.js'
+        },
+        dataProvider: {
+          type: 'node.js',
+          hashKey: 'single-flight-burst-provider',
+          src: 'server.js'
+        },
+        env: '.env'
+      }
+    }
+  };
+  const dataProviderSource = [
+    '"use strict";',
+    'module.exports.data = function data(context, callback) {',
+    '  callback(null, { envValue: context.env.BURST_ENV });',
+    '};'
+  ].join('\n');
+  const compiledViewSource = [
+    'var oc = oc || {};',
+    'oc.components = oc.components || {};',
+    `oc.components[${JSON.stringify(templateHash)}] = function (data) {`,
+    '  return "<div>" + data.envValue + "</div>";',
+    '};'
+  ].join('\n');
+  const calls = {
+    getDataProvider: 0,
+    getCompiledView: 0,
+    getEnv: 0
+  };
+  let downstreamInFlight = 0;
+  let peakConcurrentDownstreamReads = 0;
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const downstreamRead = async (method, createResult) => {
+    calls[method]++;
+    downstreamInFlight++;
+    peakConcurrentDownstreamReads = Math.max(
+      peakConcurrentDownstreamReads,
+      downstreamInFlight
+    );
+    try {
+      await wait(DOWNSTREAM_LATENCY_MS);
+      return createResult();
+    } finally {
+      downstreamInFlight--;
+    }
+  };
+  const repository = {
+    getComponent: async () => component,
+    getEnv: async () =>
+      downstreamRead('getEnv', () => ({ BURST_ENV: ENV_VALUE })),
+    getDataProvider: async () =>
+      downstreamRead('getDataProvider', () => ({
+        content: dataProviderSource,
+        filePath: `/${componentName}/${componentVersion}/server.js`
+      })),
+    getCompiledView: async () =>
+      downstreamRead('getCompiledView', () => compiledViewSource),
+    getTemplate: (type) =>
+      type === 'jade' || type === 'oc-template-jade' ? jadeTemplate : undefined,
+    getTemplatesInfo: () => [
+      { type: 'oc-template-jade', version: '7.0.6', externals: [] }
+    ],
+    getStaticFilePath: (_name, _version, filePath) =>
+      `//benchmark.invalid/${componentName}/${componentVersion}/${filePath}`
+  };
+  const conf = {
+    baseUrl: 'http://benchmark.invalid/',
+    dependencies: [],
+    env: {},
+    hotReloading: false,
+    local: false,
+    plugins: {},
+    refreshInterval: 0,
+    templates: []
+  };
+  const getComponent = GetComponentHelper(conf, repository);
+  const renderOne = () =>
+    new Promise((resolve, reject) => {
+      getComponent(
+        {
+          conf,
+          headers: {},
+          ip: '127.0.0.1',
+          name: componentName,
+          parameters: {},
+          version: componentVersion
+        },
+        (result) => {
+          if (result.status !== 200) {
+            reject(
+              new Error(
+                `render failed with status ${result.status}: ${
+                  result.response.code || 'unknown error'
+                }`
+              )
+            );
+            return;
+          }
+          resolve(result);
+        }
+      );
+    });
+  const baselineMemory = memorySnapshot();
+  const peakMemory = { ...baselineMemory };
+  const baselineResourceUsage = process.resourceUsage();
+  const sampleMemory = () => {
+    const current = memorySnapshot();
+    peakMemory.rssBytes = Math.max(peakMemory.rssBytes, current.rssBytes);
+    peakMemory.heapUsedBytes = Math.max(
+      peakMemory.heapUsedBytes,
+      current.heapUsedBytes
+    );
+  };
+  const sampler = setInterval(sampleMemory, MEMORY_SAMPLE_INTERVAL_MS);
+  sampler.unref();
+  const startedAt = process.hrtime.bigint();
+  let results;
+  try {
+    results = await Promise.all(Array.from({ length: n }, () => renderOne()));
+  } finally {
+    sampleMemory();
+    clearInterval(sampler);
+  }
+  const endedAt = process.hrtime.bigint();
+  const finalResourceUsage = process.resourceUsage();
+  const expectedHtml = `<div>${ENV_VALUE}</div>`;
+  if (!results.every((result) => result.response.html === expectedHtml)) {
+    throw new Error(`env coverage failed: expected every render to return ${expectedHtml}`);
+  }
+  if (downstreamInFlight !== 0) {
+    throw new Error(
+      `downstream in-flight counter did not return to zero: ${downstreamInFlight}`
+    );
+  }
+
+  return {
+    n,
+    pid: process.pid,
+    hotReloading: conf.hotReloading,
+    completedRenders: results.length,
+    downstreamCalls: calls,
+    peakConcurrentDownstreamReads,
+    wallTimeMs: Number(endedAt - startedAt) / 1e6,
+    memory: {
+      baseline: {
+        rssMb: toMb(baselineMemory.rssBytes),
+        heapUsedMb: toMb(baselineMemory.heapUsedBytes)
+      },
+      peak: {
+        rssMb: toMb(peakMemory.rssBytes),
+        heapUsedMb: toMb(peakMemory.heapUsedBytes)
+      },
+      peakDelta: {
+        rssMb: toMb(peakMemory.rssBytes - baselineMemory.rssBytes),
+        heapUsedMb: toMb(
+          peakMemory.heapUsedBytes - baselineMemory.heapUsedBytes
+        )
+      }
+    },
+    cpu: {
+      userTimeMs:
+        (finalResourceUsage.userCPUTime - baselineResourceUsage.userCPUTime) /
+        1000,
+      systemTimeMs:
+        (finalResourceUsage.systemCPUTime -
+          baselineResourceUsage.systemCPUTime) /
+        1000
+    }
+  };
+};
+
+const workerN = process.env[WORKER_ENV];
+if (workerN === undefined) {
+  try {
+    runParent();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+} else {
+  runWorker(Number.parseInt(workerN, 10))
+    .then((result) => writeAndExit(result, 0))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/packages/oc/tasks/benchmarks/storage-adapter.js
+++ b/packages/oc/tasks/benchmarks/storage-adapter.js
@@ -21,10 +21,18 @@ const createStorageAdapter = (options) => {
   const maxLatencyMs = options.maxLatencyMs ?? 25;
   const maxConcurrentRequests = options.maxConcurrentRequests ?? 128;
   const fixtureRoot = path.resolve(options.fixturesRoot);
+  let activeReads = 0;
+  let peakConcurrentReads = 0;
 
   const withLatency = async (fn) => {
-    await wait(randomLatency(minLatencyMs, maxLatencyMs));
-    return fn();
+    activeReads++;
+    peakConcurrentReads = Math.max(peakConcurrentReads, activeReads);
+    try {
+      await wait(randomLatency(minLatencyMs, maxLatencyMs));
+      return await fn();
+    } finally {
+      activeReads--;
+    }
   };
 
   const readTextFile = async (relativePath) =>
@@ -45,6 +53,12 @@ const createStorageAdapter = (options) => {
   return {
     adapterType: 'benchmark-memory',
     maxConcurrentRequests,
+    getMetrics() {
+      return { activeReads, peakConcurrentReads };
+    },
+    resetMetrics() {
+      peakConcurrentReads = activeReads;
+    },
     async getFile(filePath) {
       return readTextFile(filePath);
     },

--- a/packages/oc/test/unit/registry-domain-events-handler.js
+++ b/packages/oc/test/unit/registry-domain-events-handler.js
@@ -53,6 +53,28 @@ describe('registry : domain : events-handler', () => {
     });
   });
 
+  describe('when checking for subscribers', () => {
+    const listener = () => {};
+
+    afterEach(() => {
+      eventsHandler.reset();
+    });
+
+    it('should reflect on, off, and reset changes', () => {
+      expect(eventsHandler.hasListeners('request')).to.be.false;
+
+      eventsHandler.on('request', listener);
+      expect(eventsHandler.hasListeners('request')).to.be.true;
+
+      eventsHandler.off('request', listener);
+      expect(eventsHandler.hasListeners('request')).to.be.false;
+
+      eventsHandler.on('request', listener);
+      eventsHandler.reset();
+      expect(eventsHandler.hasListeners('request')).to.be.false;
+    });
+  });
+
   describe('when subscribing a request event using a not valid handler', () => {
     const execute = () => {
       eventsHandler.on('request', 'this is not a function');

--- a/packages/oc/test/unit/registry-domain-nested-renderer.js
+++ b/packages/oc/test/unit/registry-domain-nested-renderer.js
@@ -180,6 +180,33 @@ describe('registry : routes : helpers : nested-renderer', () => {
   });
 
   describe('when rendering nested components', () => {
+    describe('when limiting concurrency', () => {
+      it('should preserve order and run at most ten renders at once', async () => {
+        let active = 0;
+        let maxActive = 0;
+        renderer = sinon.stub().callsFake((options, callback) => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          setTimeout(() => {
+            active--;
+            callback({
+              status: 200,
+              response: { html: options.name }
+            });
+          }, 12 - Number(options.name));
+        });
+        nestedRenderer = NestedRenderer(renderer, {});
+        const components = Array.from({ length: 12 }, (_, index) => ({
+          name: String(index)
+        }));
+
+        const result = await nestedRenderer.renderComponents(components);
+
+        expect(maxActive).to.equal(10);
+        expect(result).to.eql(components.map((component) => component.name));
+      });
+    });
+
     describe('when req is not valid', () => {
       describe('when components not valid', () => {
         beforeEach(() => {

--- a/packages/oc/test/unit/registry-domain-version-handler.js
+++ b/packages/oc/test/unit/registry-domain-version-handler.js
@@ -31,6 +31,14 @@ describe('registry : domain : version-handler', () => {
         expect(get('hello!', availableVersions)).to.be.undefined;
       });
 
+      it('should return an exact existing version', () => {
+        expect(get('1.0.1', availableVersions)).to.equal('1.0.1');
+      });
+
+      it('should return undefined for a missing exact version', () => {
+        expect(get('9.9.9', availableVersions)).to.be.undefined;
+      });
+
       it('should return the latest when latest version specified', () => {
         expect(get('', availableVersions)).to.equal('2.0.0');
       });

--- a/packages/oc/test/unit/registry-routes-component.js
+++ b/packages/oc/test/unit/registry-routes-component.js
@@ -703,10 +703,11 @@ describe('registry : routes : component', () => {
     });
 
     it('should return "response-headers-component" name for the first component\'s name and request version', () => {
-      expect(resJsonStub.args[0][0].name).to.equal(
-        'another-response-headers-component'
-      );
-      expect(resJsonStub.args[0][0].requestVersion).to.equal('1.X.X');
+      const response = resJsonStub.args
+        .map(([result]) => result)
+        .find((result) => result.name === 'another-response-headers-component');
+      expect(response.name).to.equal('another-response-headers-component');
+      expect(response.requestVersion).to.equal('1.X.X');
     });
 
     it('should set response headers for the first component', () => {
@@ -722,8 +723,11 @@ describe('registry : routes : component', () => {
     });
 
     it('should return "simple-component" name for the second component\'s name and request version', () => {
-      expect(resJsonStub.args[1][0].name).to.equal('simple-component');
-      expect(resJsonStub.args[1][0].requestVersion).to.equal('1.X.X');
+      const response = resJsonStub.args
+        .map(([result]) => result)
+        .find((result) => result.name === 'simple-component');
+      expect(response.name).to.equal('simple-component');
+      expect(response.requestVersion).to.equal('1.X.X');
     });
 
     it('should not set custom response for the second component', () => {

--- a/packages/oc/test/unit/registry-routes-helpers-get-component.js
+++ b/packages/oc/test/unit/registry-routes-helpers-get-component.js
@@ -33,7 +33,7 @@ describe('registry : routes : helpers : get-component', () => {
           };
         }
       },
-      { console, Buffer, setTimeout }
+      { console, Buffer, clearTimeout, setTimeout }
     ).default;
 
     mockedRepository = {
@@ -428,6 +428,81 @@ describe('registry : routes : helpers : get-component', () => {
           );
         });
       });
+    });
+  });
+
+  describe('when concurrent cold renders request the same component', () => {
+    const renderTwice = (done) => {
+      const simpleComponent = mockedComponents['simple-component'];
+      initialise({
+        ...simpleComponent,
+        package: {
+          ...simpleComponent.package,
+          name: 'single-flight-component',
+          version: '9.9.9'
+        }
+      });
+      const getComponent = GetComponent({}, mockedRepository);
+      let completed = 0;
+      const callback = () => {
+        completed++;
+        if (completed === 2) done();
+      };
+      const options = {
+        name: 'simple-component',
+        headers: {},
+        parameters: {},
+        version: '1.0.0',
+        conf: { baseUrl: 'http://components.com/' }
+      };
+
+      getComponent(options, callback);
+      getComponent(options, callback);
+    };
+
+    it('should load and compile server.js and the template once', (done) => {
+      renderTwice(() => {
+        try {
+          expect(mockedRepository.getDataProvider.calledOnce).to.be.true;
+          expect(mockedRepository.getCompiledView.calledOnce).to.be.true;
+          done();
+        } catch (error) {
+          done(error);
+        }
+      });
+    });
+  });
+
+  describe('when a provider completes before its execution timeout', () => {
+    it('should clear the pending timeout', (done) => {
+      const clock = sinon.useFakeTimers();
+      initialise(mockedComponents['simple-component']);
+      const getComponent = GetComponent({}, mockedRepository);
+
+      getComponent(
+        {
+          name: 'simple-component',
+          headers: {},
+          parameters: {},
+          version: '1.0.0',
+          conf: {
+            baseUrl: 'http://components.com/',
+            executionTimeout: 1
+          }
+        },
+        (result) => {
+          try {
+            expect(result.status).to.equal(200);
+            expect(clock.countTimers()).to.equal(0);
+            expect(result).not.to.have.property('headers');
+            clock.restore();
+            done();
+          } catch (error) {
+            clock.restore();
+            done(error);
+          }
+        }
+      );
     });
   });
 });

--- a/plans/001-component-route-performance-wins.md
+++ b/plans/001-component-route-performance-wins.md
@@ -1,0 +1,497 @@
+# Plan 001: Improve high-traffic component route performance without long-lived metadata caching
+
+> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving to the next step. If anything in the "STOP conditions" section occurs, stop and report; do not improvise. When done, update the status row for this plan in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 35b22556..HEAD -- packages/oc/src/registry packages/oc-fastify-server-adapter/src/index.ts plans`
+> If any in-scope file changed since this plan was written, compare the "Current state" excerpts against the live code before proceeding. On a mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: L
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: perf
+- **Planned at**: commit `35b22556`, 2026-07-23
+
+## Why This Matters
+
+The component route flow is the high-traffic path for OC registries: single component GETs, batch POSTs, and nested component renders all converge through `GetComponentHelper`. The highest-value improvements are the ones that reduce burst amplification, per-request middleware overhead, and repeated hot-path allocations without introducing large long-lived caches. This plan explicitly excludes full component `package.json` metadata caching because that can grow heap with the number of component versions and needs a separate bounded-cache design.
+
+The target trade-off is: less duplicated I/O, VM/template compile work, timer churn, and unbounded concurrency, while keeping steady-state memory flat or lower under load.
+
+## Current State
+
+Relevant files:
+
+| File | Role |
+|------|------|
+| `packages/oc/src/registry/routes/helpers/get-component.ts` | Main component render helper; loads env/server/template files, executes data providers, renders templates. |
+| `packages/oc/src/registry/routes/components.ts` | Batch component POST route. |
+| `packages/oc/src/registry/domain/nested-renderer.ts` | Nested `renderComponent` and `renderComponents` implementation exposed to data providers. |
+| `packages/oc/src/registry/domain/version-handler.ts` | Resolves requested component versions. |
+| `packages/oc/src/registry/domain/validators/plugins-requirements.ts` | Validates component plugin requirements against registry plugins. |
+| `packages/oc/src/registry/middleware/index.ts` | Registers global middleware, request timing, body parsing, uploads, CORS, dynamic config helpers. |
+| `packages/oc/src/registry/domain/events-handler.ts` | Event subscription and dispatch implementation. |
+| `packages/oc/src/registry/domain/http-server/express-adapter.ts` | Default Express adapter. |
+| `packages/oc-fastify-server-adapter/src/index.ts` | Fastify adapter. |
+
+Current code facts to preserve:
+
+```ts
+// packages/oc/src/registry/routes/helpers/get-component.ts:499-554
+const cacheKey = `${component.name}/${component.version}/template.js`;
+const cached = cache.get('file-contents', cacheKey);
+...
+if (cached && !conf.hotReloading) {
+  returnResult(cached);
+} else {
+  fromPromise(repository.getCompiledView)(
+    component.name,
+    component.version,
+    (_err, templateText) => {
+      const template = ocTemplate.getCompiledTemplate(templateText, key);
+      cache.set('file-contents', cacheKey, template);
+      returnResult(template);
+    }
+  );
+}
+```
+
+```ts
+// packages/oc/src/registry/routes/helpers/get-component.ts:571-747
+fromPromise(getEnv)(component, (err, env) => {
+  ...
+  const cacheKey = `${component.name}/${component.version}/server.js`;
+  const cached = cache.get('file-contents', cacheKey);
+  const domain = Domain.create();
+  ...
+  if (cached && !conf.hotReloading) {
+    domain.on('error', returnComponent);
+    ...
+  } else {
+    fromPromise(repository.getDataProvider)(
+      component.name,
+      component.version,
+      (err, dataProvider) => {
+        ...
+        vm.runInNewContext(dataProvider.content, context, options);
+        const processData =
+          context.module.exports['data'] || context.exports['data'];
+        cache.set('file-contents', cacheKey, processData);
+        ...
+      }
+    );
+  }
+});
+```
+
+```ts
+// packages/oc/src/registry/routes/components.ts:89-105
+async.map(
+  components,
+  (component, callback) => {
+    getComponent(...);
+  },
+  ...
+);
+```
+
+```ts
+// packages/oc/src/registry/domain/nested-renderer.ts:68-85
+return Promise.all(
+  components.map((component) => {
+    return renderer(...).catch((err) => new Error(err));
+  })
+);
+```
+
+```ts
+// packages/oc/src/registry/middleware/index.ts:19-50
+adapter.enableRequestTiming((req, res, time) => {
+  const data: RequestData = {
+    body: req.body,
+    duration: time,
+    headers: req.headers,
+    method: req.method,
+    path: req.path,
+    relativeUrl: req.originalUrl,
+    query: req.query,
+    url: req.protocol + '://' + req.get('host') + req.originalUrl,
+    statusCode: res.statusCode
+  };
+  eventsHandler.fire('request', data);
+});
+...
+if (!options.local) {
+  adapter.enableFileUploads(...);
+}
+```
+
+```ts
+// packages/oc-fastify-server-adapter/src/index.ts:225-275
+this.app.addHook('preHandler', async (request) => {
+  const req = request as FastifyRequestWithState;
+  if (
+    req[multipartParsedSym] ||
+    typeof req.isMultipart !== 'function' ||
+    !req.isMultipart()
+  ) {
+    return;
+  }
+  ...
+});
+```
+
+```ts
+// packages/oc/src/registry/domain/http-server/express-adapter.ts:91-106
+enableFileUploads(opts) {
+  const upload = multer(...);
+  this.app.use(upload.any());
+}
+```
+
+```ts
+// packages/oc/src/registry/routes/helpers/get-component.ts:633-641
+const setCallbackTimeout = () => {
+  const executionTimeout = conf.executionTimeout;
+  if (executionTimeout) {
+    setTimeout(() => {
+      const message = `timeout (${executionTimeout * 1000}ms)`;
+      returnComponent({ message }, undefined);
+      domain.exit();
+    }, executionTimeout * 1000);
+  }
+};
+```
+
+Repo conventions:
+
+- TypeScript source lives under `packages/*/src` and builds to `dist`.
+- `packages/oc` unit tests are mostly CommonJS under `packages/oc/test/unit` and run against built `dist` files through `node tasks/mochaTest.js`.
+- `packages/oc-fastify-server-adapter` uses Jest and TypeScript source tests.
+- Use existing small helper style. Avoid broad rewrites and avoid changing response shapes.
+
+## Commands You Will Need
+
+Run commands from the repository root unless noted.
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build `oc` | `npm --workspace packages/oc run build` | exit 0, lint + TypeScript + build complete |
+| Test `oc` | `npm --workspace packages/oc run test-silent` | exit 0, all tests pass |
+| Benchmark `oc` | `npm --workspace packages/oc run bench:quick` | exit 0, benchmark completes and prints scenario results |
+| Build Fastify adapter | `npm --workspace packages/oc-fastify-server-adapter run build` | exit 0, lint + TypeScript complete |
+| Test Fastify adapter | `npm --workspace packages/oc-fastify-server-adapter run test-silent` | exit 0, Jest and integration tests pass |
+
+## Scope
+
+**In scope**:
+
+- `packages/oc/src/registry/routes/helpers/get-component.ts`
+- `packages/oc/src/registry/routes/components.ts`
+- `packages/oc/src/registry/domain/nested-renderer.ts`
+- `packages/oc/src/registry/domain/version-handler.ts`
+- `packages/oc/src/registry/domain/validators/plugins-requirements.ts`
+- `packages/oc/src/registry/middleware/index.ts`
+- `packages/oc/src/registry/domain/events-handler.ts`
+- `packages/oc/src/registry/domain/http-server/types.ts`
+- `packages/oc/src/registry/domain/http-server/express-adapter.ts`
+- `packages/oc-fastify-server-adapter/src/index.ts`
+- Relevant tests under `packages/oc/test/unit` and `packages/oc-fastify-server-adapter/test`
+- This plan file and `plans/README.md` status updates
+
+**Out of scope**:
+
+- Full component `package.json` metadata caching.
+- Registry UI route behavior, HTML view output, and preview/info page changes.
+- Response JSON shape changes for component routes.
+- Removing Node `Domain` from data-provider execution. That is a larger compatibility-risk refactor.
+- Storage adapter implementation changes.
+
+## Git Workflow
+
+- Do not commit, push, or open a PR unless explicitly instructed by the operator.
+- If committing is requested later, use a concise conventional-style message like `perf: reduce component route hot-path overhead`.
+- Never revert unrelated worktree changes.
+
+## Steps
+
+### Step 1: Add single-flight dedupe for cold template, server, and env loads
+
+In `packages/oc/src/registry/routes/helpers/get-component.ts`, add a small helper local to `getComponent(conf, repository)` that dedupes in-flight async work by cache namespace/key.
+
+Target behavior:
+
+- If `conf.hotReloading` is true, preserve current behavior and do not use the long-lived compiled cache for server/template code.
+- For non-hot-reload cache misses, store an in-flight `Promise` keyed by the same logical keys currently used:
+  - `${component.name}/${component.version}/template.js`
+  - `${component.name}/${component.version}/server.js`
+  - `${component.name}/${component.version}/.env`
+- Delete the in-flight entry in `finally`, whether the operation resolves or rejects.
+- Do not cache rejected results.
+- Keep the existing `nice-cache` as the resolved-value cache.
+
+Implementation guidance:
+
+- Prefer one `Map<string, Promise<unknown>>` inside `getComponent(conf, repository)`.
+- Wrap `repository.getCompiledView + ocTemplate.getCompiledTemplate` as a shared promise before invoking `returnResult(template)`.
+- Wrap `repository.getDataProvider + vm.runInNewContext + processData extraction` as a shared promise that resolves to the `processData` function and caches it only after successful VM execution.
+- Wrap `getEnv` similarly, or fold the single-flight logic directly into `getEnv` because it already owns the `.env` cache key.
+- Be careful not to move per-request objects such as `contextObj`, `responseHeaders`, `responseCookies`, `params`, or `domain` into shared cached state.
+
+Tests to add or update:
+
+- In `packages/oc/test/unit/registry-routes-helpers-get-component.js`, add a test that invokes the same component twice concurrently on a cold `server.js` cache and asserts `mockedRepository.getDataProvider` is called once.
+- Add a similar test for rendered templates asserting `mockedRepository.getCompiledView` is called once for concurrent cold renders.
+- If the existing callback-oriented test style makes concurrent assertions awkward, use two callbacks and finish when both have fired.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+### Step 2: Bound batch and nested render concurrency
+
+In `packages/oc/src/registry/routes/components.ts`, replace unbounded `async.map` with bounded concurrency while preserving result order.
+
+In `packages/oc/src/registry/domain/nested-renderer.ts`, replace unbounded `Promise.all(components.map(...))` with bounded concurrency while preserving result order.
+
+Implementation guidance:
+
+- Reuse the existing utility `packages/oc/src/utils/pLimit.ts` if it is suitable.
+- Use a conservative internal default such as `10` if no existing config field is appropriate.
+- Do not add a public configuration option unless necessary; this plan prefers the smallest safe hot-path fix.
+- Preserve existing behavior where nested render errors become `new Error(err)` entries rather than rejecting the whole `renderComponents` call.
+- Preserve output order exactly.
+
+Tests to add or update:
+
+- Add or update tests in `packages/oc/test/unit/registry-routes-components.js` to assert the batch route still returns results in input order.
+- Add or update tests in `packages/oc/test/unit/registry-domain-nested-renderer.js` to assert nested results remain ordered and errors remain result entries.
+- If feasible, add a simple concurrency cap test using delayed fake renders and a max-active counter.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+### Step 3: Scope multipart upload handling to publish requests
+
+Component GET/POST requests should not pay upload parsing checks. Publish routes are the only routes that need `req.files`.
+
+Implementation approach options:
+
+- Preferred: extend `HttpServerAdapter.route(...)` or add a route-scoped upload handler facility so `router.ts` can attach upload parsing only to the publish route.
+- Acceptable smaller first step: add a cheap method/path guard inside adapter upload middleware so it returns before async multipart parsing work for all non-`PUT` requests and non-publish paths.
+
+Files to inspect and update:
+
+- `packages/oc/src/registry/router.ts` publish route registration at the `put ${prefix}:componentName/:componentVersion` route.
+- `packages/oc/src/registry/routes/publish.ts`, which consumes `req.files`.
+- `packages/oc/src/registry/middleware/index.ts`, which currently enables uploads globally.
+- Both adapters: `express-adapter.ts` and `packages/oc-fastify-server-adapter/src/index.ts`.
+
+Preserve behavior:
+
+- Non-local registries still support package upload publishing.
+- Publish auth remains before publish logic, as currently registered through `adapter.fromConnect(conf.beforePublish)`.
+- Multipart field size behavior and temp-file naming remain unchanged.
+
+Tests to add or update:
+
+- Existing publish tests must still pass.
+- Add adapter-level or route-level tests, if existing harnesses make it practical, that a normal component GET does not invoke upload parsing.
+- For Fastify, add/adjust tests under `packages/oc-fastify-server-adapter/test` if route-scoped support is added there.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc-fastify-server-adapter run build` -> exit 0 if Fastify adapter changed.
+
+**Verify**: `npm --workspace packages/oc-fastify-server-adapter run test-silent` -> exit 0 if Fastify adapter changed.
+
+### Step 4: Gate request timing and event payload work when there are no listeners
+
+Currently request timing is enabled unconditionally and `middleware/index.ts` builds a `RequestData` object before `eventsHandler.fire('request', data)` can discover whether subscribers exist.
+
+Implementation guidance:
+
+- Add `hasListeners(eventName)` to `packages/oc/src/registry/domain/events-handler.ts` and its TypeScript type.
+- Optionally add `fireLazy(eventName, factory)` if that keeps call sites cleaner.
+- In `middleware/index.ts`, avoid constructing `RequestData` when there are no `request` listeners.
+- If the adapter API can accept a timing predicate without becoming complex, skip the timing hooks entirely when no request listener exists. If listener registration can happen after startup and that would break semantics, keep hooks enabled but skip payload construction.
+- Do not change `registry.on(...)` public behavior.
+
+Tests to add or update:
+
+- Add an `events-handler` unit test for `hasListeners` through `on`, `off`, and `reset`.
+- Add or update middleware tests if present; otherwise unit-test the helper behavior enough to protect event semantics.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+### Step 5: Clear execution timeout timers after provider completion
+
+In `get-component.ts`, `setCallbackTimeout` currently creates a timer per data-provider request when `conf.executionTimeout` is configured, but successful completions do not clear it.
+
+Implementation guidance:
+
+- Store the timeout handle in the render invocation scope.
+- Clear it inside the first successful or error path in `returnComponent`, before or immediately after setting `componentCallbackDone`.
+- Keep the duplicate-callback guard.
+- Do not change timeout semantics: if the timer wins, it should still call `returnComponent({ message }, undefined)` and exit the domain as it does today.
+
+Tests to add or update:
+
+- Add a fake-timer test if the test stack already supports it through Sinon.
+- Assert that a successful provider completion clears the timeout.
+- Assert that the timeout path still returns an error when the provider never calls back.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+### Step 6: Fast-path common version resolution
+
+In `packages/oc/src/registry/domain/version-handler.ts`, avoid semver range work for the common cases.
+
+Target behavior:
+
+- Empty or undefined requested version returns the latest version.
+- Exact requested version that exists returns immediately.
+- Existing range semantics remain unchanged for real semver ranges.
+
+Implementation guidance:
+
+- Available versions are sorted in `components-list.ts`, so latest can be the last entry when the list is non-empty.
+- Use `availableVersions.includes(requestedVersion)` for exact hits before `semver.maxSatisfying`.
+- Keep fallback behavior compatible for unusual version strings.
+
+Tests to add or update:
+
+- Update `packages/oc/test/unit/registry-domain-version-handler.js` or equivalent.
+- Cover undefined, empty string, exact existing version, range version, and missing exact version.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+### Step 7: Hoist stable hot-path checks and avoid needless response header objects
+
+In `get-component.ts` and `plugins-requirements.ts`, remove repeated stable work from each render.
+
+Implementation guidance:
+
+- Build `customHeadersToSkipOnWeakVersion` as a `Set` once when `GetComponentHelper(conf, repository)` is created, not inside every render.
+- Precompute registry plugin names once. Either change `plugins-requirements.ts` to accept a `Set` or add a local helper in `get-component.ts`. Keep the public validator behavior compatible if it is imported elsewhere.
+- Cache plugin compatibility and template min OC validation per component version only if the cache is bounded by existing component/template cache lifecycle, or if it stores tiny boolean/result objects keyed by component version. Do not cache full package metadata.
+- Keep `responseHeaders` undefined until `contextObj.setHeader` is called.
+- Only include `headers` in `GetComponentResult` when headers exist.
+- Preserve response shape except omitting empty `headers` internal property; external JSON responses should not gain or lose documented fields.
+
+Tests to add or update:
+
+- Existing custom header tests should still pass.
+- Add or update tests for a component that does not call `setHeader`, asserting the route does not attempt to set empty headers if there is a convenient spy.
+- Add plugin requirement validation tests if changing validator inputs.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+### Step 8: Lazy parse headers used by only some components or negotiation paths
+
+In `get-component.ts`, reduce per-render parsing/allocation for headers that are not always needed.
+
+Implementation guidance:
+
+- Move `parseTemplatesHeader(...)` inside the `isUnrendered && isValidClientRequest && options.headers['templates']` branch.
+- Replace `options.headers['user-agent'].match('oc-client-')` with `String(...).includes('oc-client-')` or equivalent.
+- Make `contextObj.acceptLanguage` a lazy getter that memoizes `acceptLanguageParser.parse(rawValue)` on first access.
+- Preserve support for `__ocAcceptLanguage` parameter override.
+- Ensure `contextObj` still behaves like an object for component data providers.
+
+Tests to add or update:
+
+- Existing unrendered negotiation tests in `registry-routes-helpers-get-component.js` must still pass.
+- Add a test, if practical with injection/spies, that rendered requests with a `templates` header do not call `parseTemplatesHeader` or equivalent parsing code.
+- Add/keep a test proving `acceptLanguage` is available when a component reads it.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run test-silent` -> exit 0.
+
+### Step 9: Benchmark and compare
+
+After all functional tests pass, run the quick benchmark.
+
+**Verify**: `npm --workspace packages/oc run bench:quick` -> exit 0.
+
+Expected result:
+
+- Benchmark completes without failures.
+- RPS should be neutral or better.
+- P95 latency should be neutral or better, especially on high-concurrency or storage-backed scenarios.
+- Heap/RSS should be neutral or lower under bursty scenarios because single-flight and bounded fan-out reduce duplicate work.
+
+If benchmark numbers are noisy, do not overfit. Record the before/after output in the implementation notes or PR description if one is created.
+
+## Test Plan
+
+Required tests:
+
+- Concurrent cold `server.js` load dedupes to one `getDataProvider` call.
+- Concurrent cold template load dedupes to one `getCompiledView` call.
+- Batch route preserves response order under concurrency limiting.
+- Nested `renderComponents` preserves response order and error-as-result behavior.
+- Publish upload flow still works.
+- Request event listener behavior is unchanged, including `on`, `off`, and `reset`.
+- Execution timeout timer is cleared after successful provider completion and still fires for hung providers.
+- Version handler covers latest, exact, range, and missing versions.
+- Unrendered template negotiation behavior remains unchanged.
+
+Verification commands:
+
+- `npm --workspace packages/oc run build` -> exit 0.
+- `npm --workspace packages/oc run test-silent` -> exit 0.
+- `npm --workspace packages/oc-fastify-server-adapter run build` -> exit 0 if Fastify adapter changed.
+- `npm --workspace packages/oc-fastify-server-adapter run test-silent` -> exit 0 if Fastify adapter changed.
+- `npm --workspace packages/oc run bench:quick` -> exit 0.
+
+## Done Criteria
+
+All must hold:
+
+- [ ] No full component `package.json` metadata cache was added.
+- [ ] Single-flight entries are deleted after resolve or reject and do not cache failures.
+- [ ] Batch and nested render result ordering is preserved.
+- [ ] Component route response JSON shape is unchanged.
+- [ ] Publish upload behavior still works for non-local registries.
+- [ ] `registry.on(...)`, `off`, and `reset` event behavior remains compatible.
+- [ ] Execution timeout behavior is preserved and successful provider calls clear their timer.
+- [ ] `npm --workspace packages/oc run build` exits 0.
+- [ ] `npm --workspace packages/oc run test-silent` exits 0.
+- [ ] `npm --workspace packages/oc run bench:quick` exits 0.
+- [ ] Fastify adapter build/tests pass if `packages/oc-fastify-server-adapter/src/index.ts` changed.
+- [ ] `plans/README.md` status row updated.
+
+## STOP Conditions
+
+Stop and report back if:
+
+- The current code no longer matches the excerpts above after the drift check.
+- Upload parsing cannot be scoped or cheaply guarded without changing publish auth/order semantics.
+- Single-flight dedupe requires sharing per-request state such as `contextObj`, `domain`, `params`, headers, cookies, or response objects.
+- Concurrency limiting would require a public config option or response contract change.
+- Event timing gating would break dynamic listener registration semantics.
+- Benchmarks show a consistent regression larger than normal noise after two runs.
+- A verification command fails twice after reasonable fix attempts.
+
+## Maintenance Notes
+
+- Single-flight dedupe is intentionally not a long-lived metadata cache. It should only collapse concurrent misses and then hand off to the existing resolved-value cache.
+- If future work adds full component metadata caching, it should be a separate bounded LRU/TTL design with heap measurements.
+- Reviewers should scrutinize request-specific state capture in the single-flight implementation. Accidentally sharing request context across requests would be a correctness bug.
+- Reviewers should scrutinize upload scoping because publish route behavior is externally visible.
+- If registries rely heavily on very large batch requests, tune the internal concurrency limit based on benchmark data rather than increasing it blindly.

--- a/plans/002-benchmark-burst-and-batch-scenarios.md
+++ b/plans/002-benchmark-burst-and-batch-scenarios.md
@@ -1,0 +1,280 @@
+# Plan 002: Prove (or disprove) Plan 001's burst and batch wins with targeted benchmark scenarios
+
+> **Executor instructions**: Follow this plan step by step. This is a measurement/benchmark task, not a product-code change. Do NOT modify any file under `packages/oc/src` or `packages/oc-fastify-server-adapter/src` except as an explicit A/B toggle via `git stash` (Step 5). Run every verification command and record its output. If a STOP condition occurs, stop and report; do not improvise.
+>
+> **Goal**: Plan 001's `bench:quick` A/B was neutral because the only built-in scenarios are warm-cache single-component GETs. They do not exercise the two changes with the biggest theoretical upside:
+> - **Single-flight dedupe** (`get-component.ts`) — collapses concurrent cold-cache misses for the same component into one downstream load.
+> - **Bounded fan-out** (`components.ts` batch route, `nested-renderer.ts`) — caps concurrency at 10 for batch/nested renders.
+>
+> This plan adds two scenarios that create those conditions, and measures old-vs-new on the same machine.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW (benchmark tooling only; no shipped behavior change)
+- **Depends on**: Plan 001 (its changes are the subject under test; leave them in the working tree)
+- **Category**: perf-measurement
+- **Planned at**: 2026-07-23
+
+## Why This Matters
+
+Plan 001 is currently justified on tail-risk/hygiene grounds, not measured throughput. Before merging, we want empirical answers to two questions:
+
+1. **Single-flight**: under a concurrent cold-cache burst for one component, does the new code do **1** downstream `getDataProvider`/`getCompiledView`/`getEnv` load instead of **N**, and does that lower wall-time, peak concurrency, and peak memory?
+2. **Bounded fan-out**: for large batch POSTs, does capping concurrency at 10 (a) protect tail latency / heap under load, and (b) **not regress** throughput for legitimate large batches?
+
+If neither scenario shows a difference even under adversarial load, that is a valid result: recommend dropping single-flight (the most complex piece) and keeping the rest of Plan 001 on hygiene grounds.
+
+## Critical facts about the harness (read before writing code)
+
+These were verified in the codebase. Getting them wrong will produce false "no difference" results.
+
+1. **Load generator is `bombardier`** (Go binary), invoked via `spawn('bombardier', ...)` in `packages/oc/tasks/benchmarks/server-benchmark.js:239` (`runBombardier`). It is installed (`bombardier 2.0.2`). It is NOT autocannon.
+2. **`runBombardier` currently hardcodes GET and sends no body** (`server-benchmark.js:511` sets `method: 'GET'`; there is no `-b`/body plumbing). The batch scenario requires extending it to send `POST` + a JSON body + `Content-Type: application/json`.
+3. **The registry runs in-process** with the benchmark (`server-benchmark.js:434` `oc.Registry(...)`, not a spawned server). Therefore `process.resourceUsage()` / `process.memoryUsage()` deltas in `startResourceMonitoring` **do** capture registry heap/RSS/CPU. Memory-spike differences from unbounded fan-out are observable here.
+4. **`nice-cache` is a process-wide singleton and never evicts the file-contents entries.** See `node_modules/nice-cache/lib/nice-cache.js`: `singleton` defaults true (so every `new Cache()` after the first returns the same instance), and `refreshInterval` only re-runs explicitly `sub()`-scribed keys — `get-component.ts` uses `set`/`get` only, so **`refreshInterval` will NOT create cold windows**. Consequences:
+   - You **cannot** force repeated cold misses in a long-running process via config. A component is cold exactly once per process.
+   - The single-flight scenario (Step 2) must therefore run as a **short burst in a fresh Node process per variant**, not as a sustained bombardier run.
+5. **Single-flight is disabled when `conf.hotReloading` is true** (by design: `get-component.ts` uses `conf.hotReloading ? loadTemplate() : singleFlight(...)`). Do not enable hotReloading in the single-flight scenario, or you will measure the "off" path in both arms.
+6. **The concurrency cap is a hardcoded `pLimit(10)`** in `components.ts` and `nested-renderer.ts`. It is not configurable; A/B (old unbounded vs new capped) is the only way to compare.
+7. **The committed baseline `test/results/benchmarks/server-benchmark-baseline.json` is stale** (Plan 001 review saw a +310% swing on it). Ignore the tool's "vs Baseline" print. The only trustworthy comparison is a same-machine A/B (Step 5). Result JSON files in `test/results/benchmarks/` are git-ignored.
+
+## Current State
+
+Relevant files:
+
+| File | Role |
+|------|------|
+| `packages/oc/tasks/benchmarks/server-benchmark.js` | Scenario definitions, registry startup, bombardier runner, aggregation, comparison. |
+| `packages/oc/tasks/benchmarks/storage-adapter.js` | Simulated storage adapter with per-read latency (`minLatencyMs`/`maxLatencyMs`, default 8–30ms). No concurrency counter yet. |
+| `packages/oc/test/fixtures/benchmark-components/welcome-with-plugin` | The only component copied into storage fixtures today (`prepareStorageFixtures`, `server-benchmark.js:208`). |
+| `packages/oc/test/fixtures/components/*` | Many distinct local components (welcome, hello-world, no-containers, language, empty, lodash-component, ...). Used by the `local` registry. |
+
+Key anchors in `server-benchmark.js`:
+
+- `runBombardier` args builder: lines ~239–306.
+- Per-run invocation with hardcoded `method: 'GET'`: lines ~505–517.
+- `startRegistry(scenario, options)` local vs storage branches: lines ~382–461.
+- `buildScenarios()`: lines ~463–486.
+- `prepareStorageFixtures()` `componentsToCopy`: lines ~202–237.
+- `getScenarioOptions` / `baseOptions` (connections default 100, duration 15s, storage latency 8–30ms): lines ~615–645.
+
+Batch endpoint contract (confirmed in `packages/oc/src/registry/routes/components.ts`):
+
+- Route: `POST /` (registry prefix `/`).
+- Body: `{ "components": [ { "name": string, "version": string, "parameters"?: object } ], "parameters"?: object, "omitHref"?: boolean }`.
+- Response: `200` with a JSON array in input order. Errors are per-entry results, not a failed request.
+- Accept header `application/json` (already the harness `DEFAULT_HEADERS`).
+
+## Commands You Will Need
+
+Run from repo root.
+
+| Purpose | Command |
+|---|---|
+| Verify bombardier | `bombardier --version` |
+| Build `oc` (required before every bench run; tests run against `dist`) | `npm --workspace packages/oc run build` |
+| Run only the new batch scenario | `npm --workspace packages/oc run bench -- --scenarios=batch-storage --repetitions=3` |
+| Run the single-flight burst harness (Step 2 script) | `node packages/oc/tasks/benchmarks/single-flight-burst.js` |
+| Existing quick bench (sanity) | `npm --workspace packages/oc run bench:quick` |
+
+Note: `npm run bench` passes flags after `--`. Confirm arg parsing in `main()` (`--key=value` form, `parseArguments`, `server-benchmark.js:579`).
+
+## Scope
+
+**In scope**:
+
+- `packages/oc/tasks/benchmarks/server-benchmark.js` (add scenarios + POST/body support).
+- `packages/oc/tasks/benchmarks/storage-adapter.js` (optional: add a peak-concurrency counter for evidence).
+- New file `packages/oc/tasks/benchmarks/single-flight-burst.js` (standalone burst harness).
+- Optionally expand storage fixtures to more distinct components for the batch scenario.
+- This plan file and `plans/README.md` status row.
+
+**Out of scope**:
+
+- Any change to `packages/oc/src/**` or `packages/oc-fastify-server-adapter/src/**` behavior. The Plan 001 diff is the device under test and must not be edited (only stashed/unstashed for A/B).
+- Changing the hardcoded `pLimit(10)` value.
+- Updating the committed baseline JSON.
+
+## Steps
+
+### Step 1: Add a batch fan-out HTTP scenario (tests bounded concurrency)
+
+**1a. Teach `runBombardier` to POST a body.**
+
+- In `server-benchmark.js`, extend the `options` consumed by `runBombardier` to include `method` and `body`. When `body` is set, append bombardier args `-m <method>` (already present via `options.method`) and `-b <body>`, and ensure a `Content-Type: application/json` header is present (either push it into the header list here or via the scenario headers).
+- At the per-run call site (~line 505), stop hardcoding `method: 'GET'`; use `scenario.method || 'GET'` and pass `scenario.body`.
+- bombardier sends the same body to every request; that is what we want.
+
+**1b. Expand storage fixtures to several distinct components** (to get real per-render storage latency AND a true fan-out that is not secretly deduped by single-flight).
+
+- In `prepareStorageFixtures()` `componentsToCopy`, add a handful of distinct components from `packages/oc/test/fixtures/components` that render with **no mandatory parameters** (e.g. `hello-world`, `no-containers`, `empty`, `language`, `lodash-component`). Each must be packaged the same way `welcome-with-plugin/_package` is; if a `_package` build is required, package them (see `tasks/build.js` / how `_package` dirs are produced) or reuse already-packaged fixtures. VERIFY the storage registry serves them (a single manual GET returns 200) before load testing.
+- Rationale: distinct components isolate the concurrency cap (Step 2 subject) from single-flight (Step 1-of-plan-001 subject). Repeating the *same* component in a batch would let single-flight dedupe the cold loads and conflate the two effects.
+
+**1c. Add the scenario.** In `buildScenarios()` add:
+
+```js
+{
+  key: 'batch-storage',
+  title: 'Batch route fan-out (storage + plugin)',
+  urlPath: '/',
+  method: 'POST',
+  // body built from the distinct components copied in 1b, e.g. 20 entries:
+  body: JSON.stringify({
+    components: [
+      { name: 'hello-world', version: '1.0.0' },
+      { name: 'no-containers', version: '1.0.0' },
+      /* ...repeat the distinct set to reach ~20-40 entries... */
+    ]
+  })
+}
+```
+
+- Wire `startRegistry` so `batch-storage` uses the storage branch (reuse the `storage-simulated` setup path; match on the new key alongside the existing keys at `server-benchmark.js:403`).
+- Keep default connections (100) and duration (15s). Consider a second run at higher `--connections` to stress the cap.
+
+**Verify**: `npm --workspace packages/oc run build` -> exit 0.
+
+**Verify**: `npm --workspace packages/oc run bench -- --scenarios=batch-storage --repetitions=3` -> exit 0, `success=100.00%` on every run (a non-100% success rate means the body/params are wrong — fix before trusting numbers).
+
+Record for this scenario: `rps`, `latencyP95Ms`, `latencyP99Ms` (available in `rawResult`), `successRate`, and `resourceUsage` heap/RSS/CPU deltas.
+
+### Step 2: Add a single-flight cold-burst harness (tests dedupe)
+
+Because of harness fact #4 (singleton cache, no eviction) this must be a **standalone script run in a fresh process per arm**, not a bombardier scenario.
+
+Create `packages/oc/tasks/benchmarks/single-flight-burst.js` that:
+
+1. `require('../../dist')` and build an **instrumented repository** (or wrap `createStorageAdapter`) whose `getDataProvider`, `getCompiledView`, and `getEnv` (or the underlying `getFile`/`getJson`) each:
+   - increment a call counter, and
+   - add a fixed latency (e.g. 30ms) to widen the cold window.
+2. Construct the component render entrypoint against a **cold** cache. Prefer the highest-level entrypoint that still lets you inject the instrumented repository — either a real `oc.Registry` with the simulated storage adapter, or `GetComponentHelper(conf, repository)` from `dist/registry/routes/helpers/get-component.js` (mirror how `packages/oc/test/unit/registry-routes-helpers-get-component.js` builds a mocked repository).
+3. Fire **N concurrent** renders (e.g. N = 50 and 200) of the **same** component/version at t=0.
+4. Wait for all to resolve, then print:
+   - `getDataProvider` / `getCompiledView` / `getEnv` call counts,
+   - peak concurrent downstream reads (track an in-flight counter in the instrumented repo),
+   - wall-clock from first dispatch to last resolve,
+   - `process.memoryUsage().rss` / `heapUsed` peak (sample during the burst) and delta.
+5. `process.exit(0)`.
+
+Expected NEW behavior: each downstream method called **once**; peak concurrency ~1; wall-clock ≈ one storage round-trip + one compile. Expected OLD behavior: each called **N** times; peak concurrency ~N; higher heap and CPU.
+
+Keep the script self-contained and deterministic (fixed latency, fixed N, no bombardier). Run each arm in its own `node` invocation so the singleton cache starts cold.
+
+**Verify**: `node packages/oc/tasks/benchmarks/single-flight-burst.js` -> exit 0 and prints the counters. On the current (NEW) tree, downstream call counts must be `1`. If they are `N`, the script is not hitting the single-flight path (check: cache cold? same cache key? `hotReloading` false? same `getComponent` instance across the N calls?) — fix before proceeding.
+
+### Step 3: Optional — peak-concurrency evidence in the storage adapter
+
+To get a second, independent signal for both scenarios, add an in-flight counter to `storage-adapter.js` `withLatency` (increment on entry, decrement on exit, track max) and expose the max via a getter or an end-of-run log. This directly shows unbounded (old) vs capped/deduped (new) downstream concurrency. Optional but strong evidence.
+
+### Step 4: Baseline the NEW tree
+
+With the Plan 001 changes present in the working tree (the current state):
+
+1. `npm --workspace packages/oc run build`
+2. `npm --workspace packages/oc run bench -- --scenarios=batch-storage --repetitions=5` — record all metrics.
+3. `node packages/oc/tasks/benchmarks/single-flight-burst.js` (run 3×) — record counts, peak concurrency, wall-time, RSS.
+
+Label these results **NEW**.
+
+### Step 5: A/B — measure the OLD tree, then restore
+
+Stash **only the Plan 001 product-code changes** (path-scoped, so the new benchmark tooling from Steps 1–3 stays in place). The Plan 001 `oc` source files are:
+
+```
+packages/oc/src/registry/routes/helpers/get-component.ts
+packages/oc/src/registry/routes/components.ts
+packages/oc/src/registry/domain/nested-renderer.ts
+packages/oc/src/registry/domain/version-handler.ts
+packages/oc/src/registry/domain/validators/plugins-requirements.ts
+packages/oc/src/registry/domain/events-handler.ts
+packages/oc/src/registry/middleware/index.ts
+packages/oc/src/registry/domain/http-server/express-adapter.ts
+```
+
+1. `git stash push -m plan001-src -- <the 8 files above>` (list them explicitly on the command line).
+2. Confirm the benchmark tooling changes (`tasks/benchmarks/*`) and the new script are still present (`git status`).
+3. `npm --workspace packages/oc run build`
+4. Re-run the exact same commands as Step 4. Label results **OLD**.
+5. `git stash pop` to restore the Plan 001 changes.
+6. `npm --workspace packages/oc run build` (leave `dist` matching the NEW tree so the worktree ends as it started).
+7. `git status` must show the same 15 Plan 001 files modified plus the new benchmark tooling; nothing from Plan 001 dropped.
+
+Reduce noise: close other apps, run on AC power, run Step 4 and Step 5 back-to-back, keep repetitions ≥ 5 for the HTTP scenario and ≥ 3 for the burst script.
+
+### Step 6: Report
+
+Produce a short markdown table NEW vs OLD for:
+
+- **batch-storage**: rps, p95, p99, success, heapUsed delta, rss delta, cpuUserTime delta (avg/min/max).
+- **single-flight burst**: downstream call counts, peak concurrency, wall-time, peak RSS — for N=50 and N=200.
+
+State a clear verdict per change:
+
+- Single-flight: kept-with-evidence, or "no measurable benefit under adversarial burst -> recommend dropping".
+- Bounded fan-out: protective win and/or no throughput regression, or a regression (if capped rps is materially below unbounded for large batches, flag it — the cap of 10 may be too low).
+
+Do not overfit to noise; if runs disagree beyond ~5%, run once more and report the range.
+
+## Implementation Results
+
+Measured on the same `darwin-arm64` machine with Node `v26.5.0`. The NEW and OLD batch runs used five repetitions, 100 connections, 15-second runs, 20 distinct component names, and 100% success. Each burst result is the average of three fresh-process runs.
+
+### Batch storage
+
+| Metric | NEW capped | OLD unbounded | Result |
+|---|---:|---:|---:|
+| RPS average (min-max) | 524.06 (511.85-537.82) | 581.05 (567.97-587.58) | -9.8% |
+| P95 ms average (min-max) | 233.06 (226.59-241.80) | 248.30 (239.01-260.03) | -6.1% |
+| P99 ms average (min-max) | 261.04 (247.69-274.21) | 277.55 (271.27-288.50) | -5.9% |
+| Success | 100% | 100% | equal |
+| Storage peak concurrency average | 998.2 | 2000.2 | -50.1% |
+| Heap delta MB average (min-max) | 16.2 (-45-103) | 14.6 (-42-89) | noisy/inconclusive |
+| RSS delta MB average (min-max) | 45.0 (-17-217) | 62.8 (-9-312) | noisy; NEW lower |
+| CPU user seconds average (min-max) | 17.24 (17.13-17.42) | 17.63 (17.49-17.85) | -2.2% |
+
+**Bounded fan-out verdict**: the cap is a clear protective win: downstream peak concurrency was halved and P95/P99 improved by about 6%. It also reduced throughput by about 9.8% in this adversarial 20-item, 100-connection workload. Keep the protection, but flag the hardcoded limit of 10 as a throughput trade-off that may need tuning for large legitimate batches.
+
+### Single-flight cold burst
+
+| N | Tree | Calls per downstream method | Peak downstream concurrency | Wall ms average | Peak RSS delta MB average | Peak heap delta MB average |
+|---:|---|---:|---:|---:|---:|---:|
+| 50 | NEW | 1 | 1 | 95.57 | 3.41 | 0.00 |
+| 50 | OLD | 50 | 50 | 112.24 | 11.84 | 8.81 |
+| 200 | NEW | 1 | 1 | 97.61 | 4.00 | 2.28 |
+| 200 | OLD | 200 | 200 | 153.11 | 51.51 | 37.22 |
+
+**Single-flight verdict**: keep with evidence. It deterministically collapsed all three cold downstream loads (`getEnv`, `getDataProvider`, and `getCompiledView`) from N to 1. At N=200 it reduced average wall time by 36%, peak RSS delta by 92%, and peak heap delta by 94%.
+
+## Test Plan / Verification
+
+- `bombardier --version` succeeds.
+- `npm --workspace packages/oc run build` -> exit 0 (both arms).
+- batch-storage runs at `success=100.00%` (both arms). A <100% rate invalidates the run.
+- single-flight-burst prints downstream call count `1` on NEW and `N` on OLD. If NEW is not 1, the scenario is mis-wired (STOP).
+- Worktree after Step 5 shows the original 15 Plan 001 files + new benchmark tooling; no Plan 001 change lost.
+
+## Done Criteria
+
+- [x] `runBombardier` supports POST + JSON body; batch-storage scenario added and green at 100% success.
+- [x] Distinct-component storage fixtures serve 200s before load testing.
+- [x] `single-flight-burst.js` exists, runs in a fresh process, and shows 1 (new) vs N (old) downstream loads.
+- [x] NEW vs OLD A/B recorded for both scenarios on the same machine (committed stale baseline ignored).
+- [x] Per-change verdict written (single-flight, bounded fan-out).
+- [x] Plan 001 working-tree changes restored intact after A/B.
+- [x] `plans/README.md` status row for 002 updated.
+
+## STOP Conditions
+
+- `bombardier` missing and cannot be installed (`brew install bombardier`).
+- single-flight-burst shows `N` downstream loads on the NEW tree after reasonable debugging (means the burst is not reaching the single-flight path — report rather than force a green).
+- batch-storage cannot reach 100% success (fixtures/params wrong) — fix or report; do not report throughput from failing requests.
+- A/B requires editing `packages/oc/src/**` beyond stash/unstash.
+- `git stash pop` conflicts or drops a Plan 001 change — stop and report; do not hand-reconstruct.
+- Two full A/B passes disagree in direction (one shows win, one shows regression) beyond noise — report as inconclusive rather than cherry-picking.
+
+## Notes for the reporter
+
+- The purpose is a go/no-go on single-flight and confirmation that the fan-out cap doesn't regress large batches — not to make `bench:quick` faster (it won't move; those scenarios don't touch this code).
+- If single-flight shows no benefit, that is an acceptable, useful outcome: recommend dropping it from Plan 001 and keeping the timer-leak fix (Step 5 of Plan 001), the fan-out cap (as protection), and the micro-opts.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,18 @@
+# Implementation Plans
+
+Generated on 2026-07-23. Execute in the order below unless dependencies say otherwise. Each executor should read the plan fully before starting, honor its STOP conditions, and update the status row when done.
+
+## Execution Order & Status
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|------|-------|----------|--------|------------|--------|
+| 001 | Improve high-traffic component route performance without long-lived metadata caching | P1 | L | - | DONE |
+| 002 | Prove/disprove Plan 001's burst and batch wins with targeted benchmark scenarios | P2 | M | 001 | DONE |
+
+## Dependency Notes
+
+- Plan 001 is standalone. It intentionally excludes full component `package.json` metadata caching because that has the clearest long-lived heap trade-off.
+
+## Findings Considered And Rejected
+
+- Full `package.json` component metadata cache: likely can reduce storage reads, but unbounded memory grows with component versions. Reconsider only with an LRU/TTL design and heap benchmarks.


### PR DESCRIPTION
## Summary
- deduplicate concurrent cold template, data-provider, and env loads while preserving hot-reload behavior
- bound batch and nested render fan-out, reduce request/upload hot-path work, and clear provider timers
- add targeted batch and cold-burst benchmarks with same-machine A/B results
- confirm single-flight collapses N downstream reads to 1; the fan-out cap halves peak storage concurrency with a documented throughput trade-off

#### Test plan
- [x] `npm --workspace packages/oc run build`
- [x] `npm --workspace packages/oc run test-silent` (943 passing)
- [x] `npm --workspace packages/oc-fastify-server-adapter run build`
- [x] `npm --workspace packages/oc-fastify-server-adapter run test-silent`
- [x] `npm --workspace packages/oc run bench:quick`
- [x] NEW/OLD `batch-storage` A/B at 100% success
- [x] NEW/OLD `single-flight-burst.js` A/B for N=50 and N=200

Generated with [Devin](https://devin.ai)