### PR TITLE
feat(registry): add dataProvider.enabled config option

### DIFF
--- a/packages/oc/src/registry/domain/options-sanitiser.ts
+++ b/packages/oc/src/registry/domain/options-sanitiser.ts
@@ -18,8 +18,24 @@ export interface RegistryOptions<
   T = any,
   TServerAdapter extends HttpServerAdapterFactory = HttpServerAdapterFactory
 > extends Partial<
-    Omit<Config<T, TServerAdapter>, 'beforePublish' | 'discovery' | 'plugins'>
+    Omit<
+      Config<T, TServerAdapter>,
+      'beforePublish' | 'dataProvider' | 'discovery' | 'plugins'
+    >
   > {
+  /**
+   * Configuration for the data provider step, i.e. the component's `server.js`
+   * that produces the model consumed by the view.
+   */
+  dataProvider?: {
+    /**
+     * Executes the component's own data provider (`server.js`) when it has one.
+     * Set to `false` to serve every component as if it shipped no `server.js`.
+     *
+     * @default true
+     */
+    enabled?: boolean;
+  };
   /**
    * Configuration object to enable/disable the HTML discovery page and the API
    *
@@ -87,6 +103,11 @@ export default function optionsSanitiser<
   if (!options.verbosity) {
     options.verbosity = 0;
   }
+
+  options.dataProvider = {
+    ...options.dataProvider,
+    enabled: options.dataProvider?.enabled !== false
+  };
 
   if (typeof options.discovery === 'boolean') {
     deprecate({

--- a/packages/oc/src/registry/domain/validators/registry-configuration.ts
+++ b/packages/oc/src/registry/domain/validators/registry-configuration.ts
@@ -6,7 +6,7 @@ import getMetadataAdapterOptions from '../metadata-adapter-options';
 type ValidationResult = { isValid: true } | { isValid: false; message: string };
 
 export default function registryConfiguration(
-  conf: Partial<Omit<Config, 'discovery'>>
+  conf: Partial<Omit<Config, 'dataProvider' | 'discovery'>>
 ): ValidationResult {
   const returnError = (message: string): ValidationResult => {
     return {

--- a/packages/oc/src/registry/routes/helpers/get-component.ts
+++ b/packages/oc/src/registry/routes/helpers/get-component.ts
@@ -613,7 +613,9 @@ export default function getComponent(conf: Config, repository: Repository) {
           .getStaticFilePath(component.name, component.version, '')
           .replace(/^https:/, '');
 
-        if (!component.oc.files.dataProvider) {
+        const dataProviderDisabled = conf.dataProvider?.enabled === false;
+
+        if (dataProviderDisabled || !component.oc.files.dataProvider) {
           const { __oc_Retry, ...props } = params;
           props['_staticPath'] = staticPath;
           props['_baseUrl'] = conf.baseUrl;

--- a/packages/oc/src/types.ts
+++ b/packages/oc/src/types.ts
@@ -254,6 +254,23 @@ export interface Config<
    */
   dependencies: string[];
   /**
+   * Configuration for the data provider step, i.e. the component's `server.js`
+   * that produces the model consumed by the view.
+   */
+  dataProvider: {
+    /**
+     * Executes the component's own data provider (`server.js`) when it has one.
+     *
+     * When `false` the registry never fetches nor runs a component's data
+     * provider, even if one exists in the storage: every component is served
+     * through the same path used by components that ship no `server.js`, i.e.
+     * the request parameters are passed straight through as the view model.
+     *
+     * @default true
+     */
+    enabled: boolean;
+  };
+  /**
    * Configuration object to enable/disable the HTML discovery page and the API
    */
   discovery: {

--- a/packages/oc/test/unit/registry-domain-options-sanitiser.js
+++ b/packages/oc/test/unit/registry-domain-options-sanitiser.js
@@ -12,7 +12,8 @@ describe('registry : domain : options-sanitiser', () => {
       hotReloading: false,
       verbosity: 0,
       customHeadersToSkipOnWeakVersion: [],
-      timeout: 120000
+      timeout: 120000,
+      dataProvider: { enabled: true }
     };
 
     for (const [property, value] of Object.entries(defaults)) {
@@ -26,6 +27,23 @@ describe('registry : domain : options-sanitiser', () => {
         require('../../dist/registry/domain/http-server/express-adapter').default
       );
       expect(sanitise(options).server.options).to.eql({ port: 3000 });
+    });
+  });
+
+  describe('dataProvider configuration', () => {
+    it('should keep dataProvider.enabled when explicitly disabled', () => {
+      const options = {
+        baseUrl: 'http://my-registry.com',
+        dataProvider: { enabled: false }
+      };
+
+      expect(sanitise(options).dataProvider).to.eql({ enabled: false });
+    });
+
+    it('should default dataProvider.enabled to true when the object is partial', () => {
+      const options = { baseUrl: 'http://my-registry.com', dataProvider: {} };
+
+      expect(sanitise(options).dataProvider).to.eql({ enabled: true });
     });
   });
 

--- a/packages/oc/test/unit/registry-routes-component.js
+++ b/packages/oc/test/unit/registry-routes-component.js
@@ -95,6 +95,62 @@ describe('registry : routes : component', () => {
     });
   });
 
+  describe('when the data provider is disabled in the registry configuration', () => {
+    let response;
+    before((done) => {
+      initialise(mockedComponents['simple-component']);
+      componentRoute = ComponentRoute({}, mockedRepository);
+
+      componentRoute(
+        {
+          headers: {
+            accept: 'application/vnd.oc.unrendered+json'
+          },
+          params: {
+            componentName: 'simple-component',
+            componentVersion: '1.X.X'
+          },
+          query: { hello: 'world' }
+        },
+        {
+          conf: {
+            baseUrl: 'http://component.com/',
+            dataProvider: { enabled: false }
+          },
+          status: (code) => ({
+            json: (json) => {
+              response = { code, json };
+              done();
+            }
+          }),
+          set: sinon.stub()
+        }
+      );
+    });
+
+    it('should return 200 status code', () => {
+      expect(response.code).to.be.equal(200);
+    });
+
+    it('should not fetch the data provider from the storage', () => {
+      expect(mockedRepository.getDataProvider.called).to.be.false;
+    });
+
+    it('should use the request parameters as the view model', () => {
+      expect(response.json.data).to.eql({
+        component: {
+          props: {
+            hello: 'world',
+            _staticPath: '//my-cdn.com/files/',
+            _baseUrl: 'http://component.com/',
+            _componentName: 'simple-component',
+            _componentVersion: '1.0.0'
+          }
+        }
+      });
+    });
+  });
+
   describe('when getting a component with a server.js that returns undefined data', () => {
     before(() => {
       initialise(mockedComponents['undefined-component']);


### PR DESCRIPTION
## What

Adds a `dataProvider` namespace to the registry configuration with an `enabled` flag (default `true`):

```js
oc.Registry({
  baseUrl: 'https://components.mycompany.com/',
  dataProvider: { enabled: false }
});
```

When `enabled` is `false`, the registry never fetches nor runs a component's `server.js`, **even if one exists in the storage**. Every component is served through the same path already used by components that ship no data provider: the request parameters are passed straight through as the view model, with `_staticPath`, `_baseUrl`, `_componentName` and `_componentVersion` appended.

## Why namespaced rather than a flat boolean

Two related features are planned: a global fallback handler (logic injected for components that have no data provider, or when they're all disabled) and middleware wrapping whichever provider ends up running. Nesting now means those land as `dataProvider.fallback` and `dataProvider.middleware` without a deprecation cycle — the sanitiser already carries shims for `s3` and `discovery` and this avoids adding a third.

`server` was deliberately avoided as a name: it is already taken by the HTTP server adapter config (`server: { adapter, options }`). `dataProvider` is also the term the codebase already uses (`component.oc.files.dataProvider`).

## Changes

- `src/types.ts` — `dataProvider: { enabled: boolean }` on `Config`.
- `src/registry/domain/options-sanitiser.ts` — `RegistryOptions` overrides it with an all-optional form (same pattern as `discovery`); default applied by spreading the user object so future keys survive.
- `src/registry/domain/validators/registry-configuration.ts` — signature accepts the pre-sanitised shape.
- `src/registry/routes/helpers/get-component.ts` — the existing "no data provider" branch now also triggers when the option is off.

The check is `conf.dataProvider?.enabled === false` rather than `!conf.dataProvider?.enabled`, because an absent `dataProvider` must continue to mean *enabled* for any config object built without going through the sanitiser.

## Behaviour note

The props-only path emits `data = { component: { props: {...} } }`, not bare props. That is pre-existing behaviour for components without a `server.js`, but it does mean a view written against a `server.js` model sees a different shape once the option is flipped on an existing registry.

## Tests

- `registry-domain-options-sanitiser` — default is `{ enabled: true }`; explicit `false` is preserved; a partial object is filled in.
- `registry-routes-component` — a component that *does* declare a `server.js` returns 200, never calls `repository.getDataProvider`, and yields the request parameters as the model.

961 unit tests passing, lint and typecheck clean.